### PR TITLE
nrf52: Remove `unsafe` `StaticRef` constructors from individual peripherals

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -277,10 +277,15 @@ unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let ficr = static_init!(
+        nrf52840::ficr::Ficr,
+        nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
+    );
+
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies
@@ -304,9 +309,6 @@ unsafe fn start() -> (
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
-
-    // Get FICR instance to read chip properties.
-    let ficr = nrf52840::ficr::Ficr::new();
 
     //--------------------------------------------------------------------------
     // CAPABILITIES

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -253,10 +253,14 @@ unsafe fn start() -> (
         [0; nrf52833::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let ficr = static_init!(
+        nrf52833::ficr::Ficr,
+        nrf52833::ficr::Ficr::new(nrf52833::chip::FICR_BASE)
+    );
     // Initialize chip peripheral drivers
     let nrf52833_peripherals = static_init!(
         Nrf52833DefaultPeripherals,
-        Nrf52833DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52833DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies
@@ -273,9 +277,6 @@ unsafe fn start() -> (
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
-
-    // Get FICR instance to read chip properties.
-    let ficr = nrf52833::ficr::Ficr::new();
 
     //--------------------------------------------------------------------------
     // RAW 802.15.4

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
@@ -194,6 +194,7 @@ pub unsafe fn start() -> (
         nrf52840::uicr::Regulator0Output::DEFAULT,
         &base_peripherals.nvmc,
         &base_peripherals.uicr,
+        &base_peripherals.approtect,
     )
     .finalize(());
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
@@ -94,10 +94,14 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let ficr = static_init!(
+        nrf52840::ficr::Ficr,
+        nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
+    );
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
     );
 
     nrf52840_peripherals

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
@@ -193,6 +193,7 @@ pub unsafe fn start() -> (
         BUTTON_RST_PIN,
         nrf52840::uicr::Regulator0Output::DEFAULT,
         &base_peripherals.nvmc,
+        &base_peripherals.uicr,
     )
     .finalize(());
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -250,6 +250,7 @@ pub unsafe fn main() {
         nrf52840::uicr::Regulator0Output::DEFAULT,
         &base_peripherals.nvmc,
         &base_peripherals.uicr,
+        &base_peripherals.approtect,
     )
     .finalize(());
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -249,6 +249,7 @@ pub unsafe fn main() {
         BUTTON_RST_PIN,
         nrf52840::uicr::Regulator0Output::DEFAULT,
         &base_peripherals.nvmc,
+        &base_peripherals.uicr,
     )
     .finalize(());
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -130,10 +130,14 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let ficr = static_init!(
+        nrf52840::ficr::Ficr,
+        nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
+    );
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
     );
 
     nrf52840_peripherals

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
@@ -213,6 +213,7 @@ pub unsafe fn main() {
         nrf52840::uicr::Regulator0Output::DEFAULT,
         &base_peripherals.nvmc,
         &base_peripherals.uicr,
+        &base_peripherals.approtect,
     )
     .finalize(());
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
@@ -119,10 +119,14 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let ficr = static_init!(
+        nrf52840::ficr::Ficr,
+        nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
+    );
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
     );
 
     nrf52840_peripherals

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
@@ -212,6 +212,7 @@ pub unsafe fn main() {
         BUTTON_RST_PIN,
         nrf52840::uicr::Regulator0Output::DEFAULT,
         &base_peripherals.nvmc,
+        &base_peripherals.uicr,
     )
     .finalize(());
 

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -286,6 +286,7 @@ pub unsafe fn start() -> (
         nrf52840::uicr::Regulator0Output::DEFAULT,
         &base_peripherals.nvmc,
         &base_peripherals.uicr,
+        &base_peripherals.approtect,
     )
     .finalize(());
 

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -285,6 +285,7 @@ pub unsafe fn start() -> (
         BUTTON_RST_PIN,
         nrf52840::uicr::Regulator0Output::DEFAULT,
         &base_peripherals.nvmc,
+        &base_peripherals.uicr,
     )
     .finalize(());
 

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -250,11 +250,15 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let ficr = static_init!(
+        nrf52840::ficr::Ficr,
+        nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
+    );
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies
@@ -297,9 +301,6 @@ pub unsafe fn start() -> (
     PANIC_RESOURCES.get().map(|resources| {
         resources.chip.put(chip);
     });
-
-    // Get FICR instance to read chip properties.
-    let ficr = nrf52840::ficr::Ficr::new();
 
     //--------------------------------------------------------------------------
     // CAPABILITIES

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -236,10 +236,15 @@ unsafe fn start() -> (
         [0; nrf52833::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let ficr = static_init!(
+        nrf52833::ficr::Ficr,
+        nrf52833::ficr::Ficr::new(nrf52833::chip::FICR_BASE)
+    );
+
     // Initialize chip peripheral drivers
     let nrf52833_peripherals = static_init!(
         Nrf52833DefaultPeripherals,
-        Nrf52833DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52833DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies
@@ -256,9 +261,6 @@ unsafe fn start() -> (
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
-
-    // Get FICR instance to read chip properties.
-    let ficr = nrf52833::ficr::Ficr::new();
 
     //--------------------------------------------------------------------------
     // RAW 802.15.4

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -260,11 +260,15 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let ficr = static_init!(
+        nrf52840::ficr::Ficr,
+        nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
+    );
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies
@@ -287,9 +291,6 @@ pub unsafe fn start() -> (
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
-
-    // Get FICR instance to read chip properties.
-    let ficr = nrf52840::ficr::Ficr::new();
 
     //--------------------------------------------------------------------------
     // CAPABILITIES

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -266,11 +266,15 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let ficr = static_init!(
+        nrf52840::ficr::Ficr,
+        nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
+    );
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies
@@ -293,9 +297,6 @@ pub unsafe fn start() -> (
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
-
-    // Get FICR instance to read chip properties.
-    let ficr = nrf52840::ficr::Ficr::new();
 
     //--------------------------------------------------------------------------
     // CAPABILITIES

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -306,6 +306,7 @@ pub unsafe fn start() -> (
         nrf52840::uicr::Regulator0Output::V3_0,
         &base_peripherals.nvmc,
         &base_peripherals.uicr,
+        &base_peripherals.approtect,
     )
     .finalize(());
 

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -305,6 +305,7 @@ pub unsafe fn start() -> (
         BUTTON_RST_PIN,
         nrf52840::uicr::Regulator0Output::V3_0,
         &base_peripherals.nvmc,
+        &base_peripherals.uicr,
     )
     .finalize(());
 

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -211,10 +211,14 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let ficr = static_init!(
+        nrf52840::ficr::Ficr,
+        nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
+    );
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies
@@ -309,9 +313,6 @@ pub unsafe fn start() -> (
         &base_peripherals.approtect,
     )
     .finalize(());
-
-    // Get FICR instance to read chip properties.
-    let ficr = nrf52840::ficr::Ficr::new();
 
     // Create capabilities that the board needs to call certain protected kernel
     // functions.

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -323,9 +323,7 @@ pub unsafe fn ieee802154_udp(
     // 802.15.4
     //--------------------------------------------------------------------------
 
-    let ficr = nrf52840::ficr::Ficr::new();
-
-    let device_id = ficr.id();
+    let device_id = nrf52840_peripherals.nrf52.ficr.id();
     let device_id_bottom_16: u16 = u16::from_le_bytes([device_id[0], device_id[1]]);
 
     let eui64_driver = components::eui64::Eui64Component::new(u64::from_le_bytes(device_id))
@@ -438,13 +436,17 @@ pub unsafe fn start_no_pconsole() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let ficr = static_init!(
+        nrf52840::ficr::Ficr,
+        nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
+    );
     // Initialize chip peripheral drivers
     //
     // SAFETY: We believe this is unique and uniquely controls DMA.
     let nrf52840_peripherals = unsafe {
         static_init!(
             Nrf52840DefaultPeripherals,
-            Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+            Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
         )
     };
 
@@ -493,9 +495,6 @@ pub unsafe fn start_no_pconsole() -> (
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
-
-    // Get FICR instance to read chip properties.
-    let ficr = nrf52840::ficr::Ficr::new();
 
     // Create (and save for panic debugging) a chip object to setup low-level
     // resources (e.g. MPU, systick).

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -512,6 +512,7 @@ pub unsafe fn start_no_pconsole() -> (
         nrf52840::uicr::Regulator0Output::DEFAULT,
         &base_peripherals.nvmc,
         &base_peripherals.uicr,
+        &base_peripherals.approtect,
     )
     .finalize(());
 

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -511,6 +511,7 @@ pub unsafe fn start_no_pconsole() -> (
         BUTTON_RST_PIN,
         nrf52840::uicr::Regulator0Output::DEFAULT,
         &base_peripherals.nvmc,
+        &base_peripherals.uicr,
     )
     .finalize(());
 

--- a/boards/nordic/nrf52_components/src/startup.rs
+++ b/boards/nordic/nrf52_components/src/startup.rs
@@ -19,8 +19,8 @@ pub struct NrfStartupComponent<'a> {
     button_rst_pin: Pin,
     reg_vout: Regulator0Output,
     nvmc: &'a nrf52::nvmc::Nvmc,
-    uicr: &'a nrf52::uicr::Uicr,
-    approtect: &'a nrf52::approtect::Approtect,
+    uicr: &'a nrf52::uicr::Uicr<'a>,
+    approtect: &'a nrf52::approtect::Approtect<'a>,
 }
 
 impl<'a> NrfStartupComponent<'a> {

--- a/boards/nordic/nrf52_components/src/startup.rs
+++ b/boards/nordic/nrf52_components/src/startup.rs
@@ -20,6 +20,7 @@ pub struct NrfStartupComponent<'a> {
     reg_vout: Regulator0Output,
     nvmc: &'a nrf52::nvmc::Nvmc,
     uicr: &'a nrf52::uicr::Uicr,
+    approtect: &'a nrf52::approtect::Approtect,
 }
 
 impl<'a> NrfStartupComponent<'a> {
@@ -29,6 +30,7 @@ impl<'a> NrfStartupComponent<'a> {
         reg_vout: Regulator0Output,
         nvmc: &'a nrf52::nvmc::Nvmc,
         uicr: &'a nrf52::uicr::Uicr,
+        approtect: &'a nrf52::approtect::Approtect,
     ) -> Self {
         Self {
             nfc_as_gpios,
@@ -36,6 +38,7 @@ impl<'a> NrfStartupComponent<'a> {
             reg_vout,
             nvmc,
             uicr,
+            approtect,
         }
     }
 }
@@ -48,8 +51,7 @@ impl Component for NrfStartupComponent<'_> {
         // hardware revisions. See
         // https://devzone.nordicsemi.com/nordic/nordic-blog/b/blog/posts/working-with-the-nrf52-series-improved-approtect.
         // If run on older HW revisions this function will do nothing.
-        let approtect = nrf52::approtect::Approtect::new();
-        approtect.sw_disable_approtect();
+        self.approtect.sw_disable_approtect();
 
         // Make non-volatile memory writable and activate the reset button
 

--- a/boards/nordic/nrf52_components/src/startup.rs
+++ b/boards/nordic/nrf52_components/src/startup.rs
@@ -19,6 +19,7 @@ pub struct NrfStartupComponent<'a> {
     button_rst_pin: Pin,
     reg_vout: Regulator0Output,
     nvmc: &'a nrf52::nvmc::Nvmc,
+    uicr: &'a nrf52::uicr::Uicr,
 }
 
 impl<'a> NrfStartupComponent<'a> {
@@ -27,12 +28,14 @@ impl<'a> NrfStartupComponent<'a> {
         button_rst_pin: Pin,
         reg_vout: Regulator0Output,
         nvmc: &'a nrf52::nvmc::Nvmc,
+        uicr: &'a nrf52::uicr::Uicr,
     ) -> Self {
         Self {
             nfc_as_gpios,
             button_rst_pin,
             reg_vout,
             nvmc,
+            uicr,
         }
     }
 }
@@ -49,25 +52,24 @@ impl Component for NrfStartupComponent<'_> {
         approtect.sw_disable_approtect();
 
         // Make non-volatile memory writable and activate the reset button
-        let uicr = nrf52::uicr::Uicr::new();
 
         // Check if we need to erase UICR memory to re-program it
         // This only needs to be done when a bit needs to be flipped from 0 to 1.
-        let psel0_reset: u32 = uicr.get_psel0_reset_pin().map_or(0, |pin| pin as u32);
-        let psel1_reset: u32 = uicr.get_psel1_reset_pin().map_or(0, |pin| pin as u32);
+        let psel0_reset: u32 = self.uicr.get_psel0_reset_pin().map_or(0, |pin| pin as u32);
+        let psel1_reset: u32 = self.uicr.get_psel1_reset_pin().map_or(0, |pin| pin as u32);
         let mut erase_uicr = ((!psel0_reset & (self.button_rst_pin as u32))
             | (!psel1_reset & (self.button_rst_pin as u32))
-            | (!(uicr.get_vout() as u32) & (self.reg_vout as u32)))
+            | (!(self.uicr.get_vout() as u32) & (self.reg_vout as u32)))
             != 0;
 
         // Only enabling the NFC pin protection requires an erase.
         if self.nfc_as_gpios {
-            erase_uicr |= !uicr.is_nfc_pins_protection_enabled();
+            erase_uicr |= !self.uicr.is_nfc_pins_protection_enabled();
         }
 
         // On new nRF52 variants we need to ensure that the APPROTECT field in UICR is
         // set to `HwDisable`.
-        if uicr.is_ap_protect_enabled() {
+        if self.uicr.is_ap_protect_enabled() {
             erase_uicr = true;
         }
 
@@ -81,40 +83,42 @@ impl Component for NrfStartupComponent<'_> {
         let mut needs_soft_reset: bool = false;
 
         // Configure reset pins
-        if uicr
+        if self
+            .uicr
             .get_psel0_reset_pin()
             .is_none_or(|pin| pin != self.button_rst_pin)
         {
-            uicr.set_psel0_reset_pin(self.button_rst_pin);
+            self.uicr.set_psel0_reset_pin(self.button_rst_pin);
             while !self.nvmc.is_ready() {}
             needs_soft_reset = true;
         }
-        if uicr
+        if self
+            .uicr
             .get_psel1_reset_pin()
             .is_none_or(|pin| pin != self.button_rst_pin)
         {
-            uicr.set_psel1_reset_pin(self.button_rst_pin);
+            self.uicr.set_psel1_reset_pin(self.button_rst_pin);
             while !self.nvmc.is_ready() {}
             needs_soft_reset = true;
         }
 
         // Configure voltage regulator output
-        if uicr.get_vout() != self.reg_vout {
-            uicr.set_vout(self.reg_vout);
+        if self.uicr.get_vout() != self.reg_vout {
+            self.uicr.set_vout(self.reg_vout);
             while !self.nvmc.is_ready() {}
             needs_soft_reset = true;
         }
 
         // Check if we need to free the NFC pins for GPIO
         if self.nfc_as_gpios {
-            uicr.set_nfc_pins_protection(true);
+            self.uicr.set_nfc_pins_protection(true);
             while !self.nvmc.is_ready() {}
             needs_soft_reset = true;
         }
 
         // If APPROTECT was not already disabled, ensure it is set to disabled.
-        if uicr.is_ap_protect_enabled() {
-            uicr.disable_ap_protect();
+        if self.uicr.is_ap_protect_enabled() {
+            self.uicr.disable_ap_protect();
             while !self.nvmc.is_ready() {}
             needs_soft_reset = true;
         }

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -257,9 +257,13 @@ pub unsafe fn start() -> (
         );
 
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let ficr = static_init!(
+        nrf52832::ficr::Ficr,
+        nrf52832::ficr::Ficr::new(nrf52832::chip::FICR_BASE)
+    );
     let nrf52832_peripherals = static_init!(
         Nrf52832DefaultPeripherals,
-        Nrf52832DefaultPeripherals::new(aes_ecb_buf)
+        Nrf52832DefaultPeripherals::new(ficr, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies
@@ -275,9 +279,6 @@ pub unsafe fn start() -> (
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
-
-    // Get FICR instance to read chip properties.
-    let ficr = nrf52832::ficr::Ficr::new();
 
     let gpio = components::gpio::GpioComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -356,6 +356,7 @@ pub unsafe fn start() -> (
         nrf52832::uicr::Regulator0Output::DEFAULT,
         &base_peripherals.nvmc,
         &base_peripherals.uicr,
+        &base_peripherals.approtect,
     )
     .finalize(());
 

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -355,6 +355,7 @@ pub unsafe fn start() -> (
         BUTTON_RST_PIN,
         nrf52832::uicr::Regulator0Output::DEFAULT,
         &base_peripherals.nvmc,
+        &base_peripherals.uicr,
     )
     .finalize(());
 

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -365,6 +365,7 @@ pub unsafe fn start_particle_boron() -> (
         nrf52840::uicr::Regulator0Output::V3_0,
         &base_peripherals.nvmc,
         &base_peripherals.uicr,
+        &base_peripherals.approtect,
     )
     .finalize(());
 

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -364,6 +364,7 @@ pub unsafe fn start_particle_boron() -> (
         BUTTON_RST_PIN,
         nrf52840::uicr::Regulator0Output::V3_0,
         &base_peripherals.nvmc,
+        &base_peripherals.uicr,
     )
     .finalize(());
 

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -196,10 +196,15 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let ficr = static_init!(
+        nrf52840::ficr::Ficr,
+        nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
+    );
+
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
     );
 
     nrf52840_peripherals

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -286,6 +286,7 @@ pub unsafe fn start() -> (
         nrf52840::uicr::Regulator0Output::V3_0,
         &base_peripherals.nvmc,
         &base_peripherals.uicr,
+        &base_peripherals.approtect,
     )
     .finalize(());
 

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -213,10 +213,15 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let ficr = static_init!(
+        nrf52840::ficr::Ficr,
+        nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
+    );
+
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies
@@ -232,9 +237,6 @@ pub unsafe fn start() -> (
 
     // Setup space to store the core kernel data structure.
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(processes.as_slice()));
-
-    // Get FICR instance to read chip properties.
-    let ficr = nrf52840::ficr::Ficr::new();
 
     // GPIOs
     let gpio = components::gpio::GpioComponent::new(

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -285,6 +285,7 @@ pub unsafe fn start() -> (
         BUTTON_PIN,
         nrf52840::uicr::Regulator0Output::V3_0,
         &base_peripherals.nvmc,
+        &base_peripherals.uicr,
     )
     .finalize(());
 

--- a/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
+++ b/boards/tutorials/nrf52840dk-thread-tutorial/src/main.rs
@@ -110,14 +110,11 @@ pub unsafe fn main() {
     let (board_kernel, base_platform, chip, nrf52840_peripherals, _mux_alarm) =
         nrf52840dk_lib::start();
 
-    // Get FICR instance to read chip properties.
-    let ficr = nrf52840::ficr::Ficr::new();
-
     //--------------------------------------------------------------------------
     // RAW 802.15.4
     //--------------------------------------------------------------------------
 
-    let device_id = ficr.id();
+    let device_id = nrf52840_peripherals.nrf52.ficr.id();
 
     let eui64 = components::eui64::Eui64Component::new(u64::from_le_bytes(device_id))
         .finalize(components::eui64_component_static!());

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -216,11 +216,15 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let ficr = static_init!(
+        nrf52840::ficr::Ficr,
+        nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
+    );
 
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -243,6 +243,7 @@ pub unsafe fn start() -> (
         nrf52840::uicr::Regulator0Output::DEFAULT,
         &base_peripherals.nvmc,
         &base_peripherals.uicr,
+        &base_peripherals.approtect,
     )
     .finalize(());
 

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -242,6 +242,7 @@ pub unsafe fn start() -> (
         BUTTON_RST_PIN,
         nrf52840::uicr::Regulator0Output::DEFAULT,
         &base_peripherals.nvmc,
+        &base_peripherals.uicr,
     )
     .finalize(());
 

--- a/chips/nrf52/src/acomp.rs
+++ b/chips/nrf52/src/acomp.rs
@@ -64,7 +64,7 @@ impl Channel {
 }
 
 register_structs! {
-    CompRegisters {
+    pub CompRegisters {
         /// TASK REGISTERS
         /// Trigger task by writing 1
         /// start comparator. Needed before comparator does anything.
@@ -221,9 +221,9 @@ pub struct Comparator<'a> {
 }
 
 impl Comparator<'_> {
-    pub const fn new() -> Self {
+    pub const fn new(registers: StaticRef<CompRegisters>) -> Self {
         Comparator {
-            registers: ACOMP_BASE,
+            registers,
             client: OptionalCell::empty(),
         }
     }
@@ -333,6 +333,3 @@ impl<'a> analog_comparator::AnalogComparator<'a> for Comparator<'a> {
         self.client.set(client);
     }
 }
-
-const ACOMP_BASE: StaticRef<CompRegisters> =
-    unsafe { StaticRef::new(0x40013000 as *const CompRegisters) };

--- a/chips/nrf52/src/adc.rs
+++ b/chips/nrf52/src/adc.rs
@@ -15,7 +15,7 @@ use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{ReadOnly, ReadWrite, WriteOnly, register_bitfields};
 
 #[repr(C)]
-struct AdcRegisters {
+pub struct AdcRegisters {
     /// Start the ADC and prepare the result buffer in RAM
     tasks_start: WriteOnly<u32, TASK::Register>,
     /// Take one ADC sample, if scan is enabled all channels are sampled
@@ -244,9 +244,6 @@ pub enum AdcChannel {
     VDDHDIV5 = 0xD,
 }
 
-const SAADC_BASE: StaticRef<AdcRegisters> =
-    unsafe { StaticRef::new(0x40007000 as *const AdcRegisters) };
-
 // Buffer to save completed sample to.
 static mut SAMPLE: [u16; 1] = [0; 1];
 
@@ -349,9 +346,9 @@ pub struct Adc<'a> {
 }
 
 impl Adc<'_> {
-    pub const fn new(voltage_reference_in_mv: usize) -> Self {
+    pub const fn new(registers: StaticRef<AdcRegisters>, voltage_reference_in_mv: usize) -> Self {
         Self {
-            registers: SAADC_BASE,
+            registers,
             reference: Cell::new(voltage_reference_in_mv),
             mode: Cell::new(AdcMode::Idle),
             client: OptionalCell::empty(),

--- a/chips/nrf52/src/approtect.rs
+++ b/chips/nrf52/src/approtect.rs
@@ -23,11 +23,8 @@ use kernel::utilities::StaticRef;
 use kernel::utilities::registers::interfaces::Writeable;
 use kernel::utilities::registers::{ReadWrite, register_bitfields, register_structs};
 
-const APPROTECT_BASE: StaticRef<ApprotectRegisters> =
-    unsafe { StaticRef::new(0x40000000 as *const ApprotectRegisters) };
-
 register_structs! {
-    ApprotectRegisters {
+    pub ApprotectRegisters {
         (0x000 => _reserved0),
         (0x550 => forceprotect: ReadWrite<u32, Forceprotect::Register>),
         (0x554 => _reserved1),
@@ -55,10 +52,8 @@ pub struct Approtect {
 }
 
 impl Approtect {
-    pub const fn new() -> Approtect {
-        Approtect {
-            registers: APPROTECT_BASE,
-        }
+    pub const fn new(registers: StaticRef<ApprotectRegisters>) -> Approtect {
+        Approtect { registers }
     }
 
     /// Software disable the Access Port Protection mechanism.

--- a/chips/nrf52/src/approtect.rs
+++ b/chips/nrf52/src/approtect.rs
@@ -47,13 +47,17 @@ register_bitfields! [u32,
     ]
 ];
 
-pub struct Approtect {
+pub struct Approtect<'a> {
     registers: StaticRef<ApprotectRegisters>,
+    ficr: &'a ficr::Ficr,
 }
 
-impl Approtect {
-    pub const fn new(registers: StaticRef<ApprotectRegisters>) -> Approtect {
-        Approtect { registers }
+impl<'a> Approtect<'a> {
+    pub const fn new(
+        registers: StaticRef<ApprotectRegisters>,
+        ficr: &'a ficr::Ficr,
+    ) -> Approtect<'a> {
+        Approtect { registers, ficr }
     }
 
     /// Software disable the Access Port Protection mechanism.
@@ -65,8 +69,7 @@ impl Approtect {
     /// - <https://devzone.nordicsemi.com/f/nordic-q-a/96590/how-to-disable-approtect-permanently-dfu-is-needed>
     /// - <https://devzone.nordicsemi.com/nordic/nordic-blog/b/blog/posts/working-with-the-nrf52-series-improved-approtect>
     pub fn sw_disable_approtect(&self) {
-        let factory_config = ficr::Ficr::new();
-        match factory_config.variant() {
+        match self.ficr.variant() {
             ficr::Variant::AAF0 | ficr::Variant::Unspecified => {
                 // Newer revisions of the chip require setting the APPROTECT
                 // software register to `SwDisable`. We assume that an unspecified

--- a/chips/nrf52/src/ble_radio.rs
+++ b/chips/nrf52/src/ble_radio.rs
@@ -51,11 +51,8 @@ use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{ReadOnly, ReadWrite, WriteOnly, register_bitfields};
 use nrf5x::constants::TxPower;
 
-const RADIO_BASE: StaticRef<RadioRegisters> =
-    unsafe { StaticRef::new(0x40001000 as *const RadioRegisters) };
-
 #[repr(C)]
-struct RadioRegisters {
+pub struct RadioRegisters {
     /// Enable Radio in TX mode
     /// - Address: 0x000 - 0x004
     task_txen: WriteOnly<u32, Task::Register>,
@@ -545,9 +542,9 @@ pub struct Radio<'a> {
 }
 
 impl<'a> Radio<'a> {
-    pub const fn new() -> Radio<'a> {
+    pub const fn new(registers: StaticRef<RadioRegisters>) -> Radio<'a> {
         Radio {
-            registers: RADIO_BASE,
+            registers,
             tx_power: Cell::new(TxPower::ZerodBm),
             rx_client: OptionalCell::empty(),
             tx_client: OptionalCell::empty(),

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -25,6 +25,9 @@ const NVMC_BASE: StaticRef<crate::nvmc::NvmcRegisters> =
 const POWER_BASE: StaticRef<crate::power::PowerRegisters> =
     unsafe { StaticRef::new(0x40000000 as *const crate::power::PowerRegisters) };
 
+const PWM0_BASE: StaticRef<crate::pwm::PwmRegisters> =
+    unsafe { StaticRef::new(0x4001C000 as *const crate::pwm::PwmRegisters) };
+
 const RTC1_BASE: StaticRef<crate::rtc::RtcRegisters> =
     unsafe { StaticRef::new(0x40011000 as *const crate::rtc::RtcRegisters) };
 
@@ -124,7 +127,7 @@ impl Nrf52DefaultPeripherals<'_> {
             adc: crate::adc::Adc::new(3300),
             nvmc: crate::nvmc::Nvmc::new(NVMC_BASE),
             clock: crate::clock::Clock::new(),
-            pwm0: crate::pwm::Pwm::new(),
+            pwm0: crate::pwm::Pwm::new(PWM0_BASE),
         }
     }
     // Necessary for setting up circular dependencies

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -49,6 +49,9 @@ const TIMER1_BASE: StaticRef<crate::timer::TimerRegisters> =
 const TIMER2_BASE: StaticRef<crate::timer::TimerRegisters> =
     unsafe { StaticRef::new(0x4000A000 as *const crate::timer::TimerRegisters) };
 
+const UICR_BASE: StaticRef<crate::uicr::UicrRegisters> =
+    unsafe { StaticRef::new(0x10001200 as *const crate::uicr::UicrRegisters) };
+
 const RNG_BASE: StaticRef<crate::trng::RngRegisters> =
     unsafe { StaticRef::new(0x4000D000 as *const crate::trng::RngRegisters) };
 
@@ -92,6 +95,7 @@ pub struct Nrf52DefaultPeripherals<'a> {
     pub nvmc: crate::nvmc::Nvmc,
     pub clock: crate::clock::Clock,
     pub pwm0: crate::pwm::Pwm,
+    pub uicr: crate::uicr::Uicr,
 }
 
 impl Nrf52DefaultPeripherals<'_> {
@@ -134,6 +138,7 @@ impl Nrf52DefaultPeripherals<'_> {
             nvmc: crate::nvmc::Nvmc::new(NVMC_BASE),
             clock: crate::clock::Clock::new(),
             pwm0: crate::pwm::Pwm::new(PWM0_BASE),
+            uicr: crate::uicr::Uicr::new(UICR_BASE),
         }
     }
     // Necessary for setting up circular dependencies

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -25,6 +25,9 @@ const CLOCK_BASE: StaticRef<crate::clock::ClockRegisters> =
 const COMP_BASE: StaticRef<crate::acomp::CompRegisters> =
     unsafe { StaticRef::new(0x40013000 as *const crate::acomp::CompRegisters) };
 
+pub const FICR_BASE: StaticRef<crate::ficr::FicrRegisters> =
+    unsafe { StaticRef::new(0x10000000 as *const crate::ficr::FicrRegisters) };
+
 const NVMC_BASE: StaticRef<crate::nvmc::NvmcRegisters> =
     unsafe { StaticRef::new(0x4001E400 as *const crate::nvmc::NvmcRegisters) };
 
@@ -107,11 +110,12 @@ pub struct Nrf52DefaultPeripherals<'a> {
     pub nvmc: crate::nvmc::Nvmc,
     pub clock: crate::clock::Clock,
     pub pwm0: crate::pwm::Pwm,
-    pub uicr: crate::uicr::Uicr,
-    pub approtect: crate::approtect::Approtect,
+    pub uicr: crate::uicr::Uicr<'a>,
+    pub approtect: crate::approtect::Approtect<'a>,
+    pub ficr: &'a crate::ficr::Ficr,
 }
 
-impl Nrf52DefaultPeripherals<'_> {
+impl<'a> Nrf52DefaultPeripherals<'a> {
     /// Create default peripherals for an nRF52-based microcontroller.
     ///
     /// # Safety
@@ -124,7 +128,7 @@ impl Nrf52DefaultPeripherals<'_> {
     ///   drivers.
     /// - There must not be any other code that accesses the DMA buffer and
     ///   length registers of the DMA-enabled peripherals.
-    pub unsafe fn new(aes_ecb_buffer: &'static mut [u8; 48]) -> Self {
+    pub unsafe fn new(ficr: &'a crate::ficr::Ficr, aes_ecb_buffer: &'static mut [u8; 48]) -> Self {
         // SAFETY: See function-level doc.
         let aes_registers = unsafe { crate::aes::AesEcbRegistersManager::new(AESECB_BASE) };
 
@@ -151,8 +155,9 @@ impl Nrf52DefaultPeripherals<'_> {
             nvmc: crate::nvmc::Nvmc::new(NVMC_BASE),
             clock: crate::clock::Clock::new(CLOCK_BASE),
             pwm0: crate::pwm::Pwm::new(PWM0_BASE),
-            uicr: crate::uicr::Uicr::new(UICR_BASE),
-            approtect: crate::approtect::Approtect::new(APPROTECT_BASE),
+            uicr: crate::uicr::Uicr::new(UICR_BASE, ficr),
+            approtect: crate::approtect::Approtect::new(APPROTECT_BASE, ficr),
+            ficr,
         }
     }
     // Necessary for setting up circular dependencies

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -22,6 +22,9 @@ const COMP_BASE: StaticRef<crate::acomp::CompRegisters> =
 const NVMC_BASE: StaticRef<crate::nvmc::NvmcRegisters> =
     unsafe { StaticRef::new(0x4001E400 as *const crate::nvmc::NvmcRegisters) };
 
+const POWER_BASE: StaticRef<crate::power::PowerRegisters> =
+    unsafe { StaticRef::new(0x40000000 as *const crate::power::PowerRegisters) };
+
 const RTC1_BASE: StaticRef<crate::rtc::RtcRegisters> =
     unsafe { StaticRef::new(0x40011000 as *const crate::rtc::RtcRegisters) };
 
@@ -105,7 +108,7 @@ impl Nrf52DefaultPeripherals<'_> {
         Self {
             acomp: crate::acomp::Comparator::new(COMP_BASE),
             ecb: crate::aes::AesECB::new(aes_registers, aes_ecb_buffer),
-            pwr_clk: crate::power::Power::new(),
+            pwr_clk: crate::power::Power::new(POWER_BASE),
             ble_radio: crate::ble_radio::Radio::new(),
             trng: crate::trng::Trng::new(RNG_BASE),
             rtc: crate::rtc::Rtc::new(RTC1_BASE),

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -19,6 +19,9 @@ const AESECB_BASE: StaticRef<crate::aes::AesEcbRegisters> =
 const APPROTECT_BASE: StaticRef<crate::approtect::ApprotectRegisters> =
     unsafe { StaticRef::new(0x40000000 as *const crate::approtect::ApprotectRegisters) };
 
+const CLOCK_BASE: StaticRef<crate::clock::ClockRegisters> =
+    unsafe { StaticRef::new(0x40000000 as *const crate::clock::ClockRegisters) };
+
 const COMP_BASE: StaticRef<crate::acomp::CompRegisters> =
     unsafe { StaticRef::new(0x40013000 as *const crate::acomp::CompRegisters) };
 
@@ -146,7 +149,7 @@ impl Nrf52DefaultPeripherals<'_> {
             // Default to 3.3 V VDD reference.
             adc: crate::adc::Adc::new(SAADC_BASE, 3300),
             nvmc: crate::nvmc::Nvmc::new(NVMC_BASE),
-            clock: crate::clock::Clock::new(),
+            clock: crate::clock::Clock::new(CLOCK_BASE),
             pwm0: crate::pwm::Pwm::new(PWM0_BASE),
             uicr: crate::uicr::Uicr::new(UICR_BASE),
             approtect: crate::approtect::Approtect::new(APPROTECT_BASE),

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -64,6 +64,9 @@ const TIMER1_BASE: StaticRef<crate::timer::TimerRegisters> =
 const TIMER2_BASE: StaticRef<crate::timer::TimerRegisters> =
     unsafe { StaticRef::new(0x4000A000 as *const crate::timer::TimerRegisters) };
 
+const TWI1_BASE: StaticRef<crate::i2c::TwiRegisters> =
+    unsafe { StaticRef::new(0x40004000 as *const crate::i2c::TwiRegisters) };
+
 const UICR_BASE: StaticRef<crate::uicr::UicrRegisters> =
     unsafe { StaticRef::new(0x10001200 as *const crate::uicr::UicrRegisters) };
 
@@ -149,7 +152,7 @@ impl<'a> Nrf52DefaultPeripherals<'a> {
             uarte0: crate::uart::Uarte::new(uarte0_registers),
             spim0: crate::spi::SPIM::new(SPIM0_BASE),
             spim2: crate::spi::SPIM::new(SPIM2_BASE),
-            twi1: crate::i2c::TWI::new_twi1(),
+            twi1: crate::i2c::TWI::new(TWI1_BASE),
             // Default to 3.3 V VDD reference.
             adc: crate::adc::Adc::new(SAADC_BASE, 3300),
             nvmc: crate::nvmc::Nvmc::new(NVMC_BASE),

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -31,6 +31,12 @@ const PWM0_BASE: StaticRef<crate::pwm::PwmRegisters> =
 const RTC1_BASE: StaticRef<crate::rtc::RtcRegisters> =
     unsafe { StaticRef::new(0x40011000 as *const crate::rtc::RtcRegisters) };
 
+const SPIM0_BASE: StaticRef<crate::spi::SpimRegisters> =
+    unsafe { StaticRef::new(0x40003000 as *const crate::spi::SpimRegisters) };
+
+const SPIM2_BASE: StaticRef<crate::spi::SpimRegisters> =
+    unsafe { StaticRef::new(0x40023000 as *const crate::spi::SpimRegisters) };
+
 const TEMP_BASE: StaticRef<crate::temperature::TempRegisters> =
     unsafe { StaticRef::new(0x4000C000 as *const crate::temperature::TempRegisters) };
 
@@ -120,9 +126,9 @@ impl Nrf52DefaultPeripherals<'_> {
             timer1: crate::timer::TimerAlarm::new(TIMER1_BASE),
             timer2: crate::timer::Timer::new(TIMER2_BASE),
             uarte0: crate::uart::Uarte::new(uarte0_registers),
-            spim0: crate::spi::SPIM::new(0),
+            spim0: crate::spi::SPIM::new(SPIM0_BASE),
+            spim2: crate::spi::SPIM::new(SPIM2_BASE),
             twi1: crate::i2c::TWI::new_twi1(),
-            spim2: crate::spi::SPIM::new(2),
             // Default to 3.3 V VDD reference.
             adc: crate::adc::Adc::new(3300),
             nvmc: crate::nvmc::Nvmc::new(NVMC_BASE),

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -31,6 +31,9 @@ const POWER_BASE: StaticRef<crate::power::PowerRegisters> =
 const PWM0_BASE: StaticRef<crate::pwm::PwmRegisters> =
     unsafe { StaticRef::new(0x4001C000 as *const crate::pwm::PwmRegisters) };
 
+const RADIO_BASE: StaticRef<crate::ble_radio::RadioRegisters> =
+    unsafe { StaticRef::new(0x40001000 as *const crate::ble_radio::RadioRegisters) };
+
 const RTC1_BASE: StaticRef<crate::rtc::RtcRegisters> =
     unsafe { StaticRef::new(0x40011000 as *const crate::rtc::RtcRegisters) };
 
@@ -129,7 +132,7 @@ impl Nrf52DefaultPeripherals<'_> {
             acomp: crate::acomp::Comparator::new(COMP_BASE),
             ecb: crate::aes::AesECB::new(aes_registers, aes_ecb_buffer),
             pwr_clk: crate::power::Power::new(POWER_BASE),
-            ble_radio: crate::ble_radio::Radio::new(),
+            ble_radio: crate::ble_radio::Radio::new(RADIO_BASE),
             trng: crate::trng::Trng::new(RNG_BASE),
             rtc: crate::rtc::Rtc::new(RTC1_BASE),
             temp: crate::temperature::Temp::new(TEMP_BASE),

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -16,6 +16,9 @@ use kernel::utilities::StaticRef;
 const AESECB_BASE: StaticRef<crate::aes::AesEcbRegisters> =
     unsafe { StaticRef::new(0x4000E000 as *const crate::aes::AesEcbRegisters) };
 
+const APPROTECT_BASE: StaticRef<crate::approtect::ApprotectRegisters> =
+    unsafe { StaticRef::new(0x40000000 as *const crate::approtect::ApprotectRegisters) };
+
 const COMP_BASE: StaticRef<crate::acomp::CompRegisters> =
     unsafe { StaticRef::new(0x40013000 as *const crate::acomp::CompRegisters) };
 
@@ -99,6 +102,7 @@ pub struct Nrf52DefaultPeripherals<'a> {
     pub clock: crate::clock::Clock,
     pub pwm0: crate::pwm::Pwm,
     pub uicr: crate::uicr::Uicr,
+    pub approtect: crate::approtect::Approtect,
 }
 
 impl Nrf52DefaultPeripherals<'_> {
@@ -142,6 +146,7 @@ impl Nrf52DefaultPeripherals<'_> {
             clock: crate::clock::Clock::new(),
             pwm0: crate::pwm::Pwm::new(PWM0_BASE),
             uicr: crate::uicr::Uicr::new(UICR_BASE),
+            approtect: crate::approtect::Approtect::new(APPROTECT_BASE),
         }
     }
     // Necessary for setting up circular dependencies

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -16,6 +16,9 @@ use kernel::utilities::StaticRef;
 const AESECB_BASE: StaticRef<crate::aes::AesEcbRegisters> =
     unsafe { StaticRef::new(0x4000E000 as *const crate::aes::AesEcbRegisters) };
 
+const COMP_BASE: StaticRef<crate::acomp::CompRegisters> =
+    unsafe { StaticRef::new(0x40013000 as *const crate::acomp::CompRegisters) };
+
 const RTC1_BASE: StaticRef<crate::rtc::RtcRegisters> =
     unsafe { StaticRef::new(0x40011000 as *const crate::rtc::RtcRegisters) };
 
@@ -97,7 +100,7 @@ impl Nrf52DefaultPeripherals<'_> {
         let uarte0_registers = unsafe { crate::uart::UarteRegistersManager::new_uarte0() };
 
         Self {
-            acomp: crate::acomp::Comparator::new(),
+            acomp: crate::acomp::Comparator::new(COMP_BASE),
             ecb: crate::aes::AesECB::new(aes_registers, aes_ecb_buffer),
             pwr_clk: crate::power::Power::new(),
             ble_radio: crate::ble_radio::Radio::new(),

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -19,6 +19,9 @@ const AESECB_BASE: StaticRef<crate::aes::AesEcbRegisters> =
 const COMP_BASE: StaticRef<crate::acomp::CompRegisters> =
     unsafe { StaticRef::new(0x40013000 as *const crate::acomp::CompRegisters) };
 
+const NVMC_BASE: StaticRef<crate::nvmc::NvmcRegisters> =
+    unsafe { StaticRef::new(0x4001E400 as *const crate::nvmc::NvmcRegisters) };
+
 const RTC1_BASE: StaticRef<crate::rtc::RtcRegisters> =
     unsafe { StaticRef::new(0x40011000 as *const crate::rtc::RtcRegisters) };
 
@@ -116,7 +119,7 @@ impl Nrf52DefaultPeripherals<'_> {
             spim2: crate::spi::SPIM::new(2),
             // Default to 3.3 V VDD reference.
             adc: crate::adc::Adc::new(3300),
-            nvmc: crate::nvmc::Nvmc::new(),
+            nvmc: crate::nvmc::Nvmc::new(NVMC_BASE),
             clock: crate::clock::Clock::new(),
             pwm0: crate::pwm::Pwm::new(),
         }

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -31,6 +31,9 @@ const PWM0_BASE: StaticRef<crate::pwm::PwmRegisters> =
 const RTC1_BASE: StaticRef<crate::rtc::RtcRegisters> =
     unsafe { StaticRef::new(0x40011000 as *const crate::rtc::RtcRegisters) };
 
+const SAADC_BASE: StaticRef<crate::adc::AdcRegisters> =
+    unsafe { StaticRef::new(0x40007000 as *const crate::adc::AdcRegisters) };
+
 const SPIM0_BASE: StaticRef<crate::spi::SpimRegisters> =
     unsafe { StaticRef::new(0x40003000 as *const crate::spi::SpimRegisters) };
 
@@ -134,7 +137,7 @@ impl Nrf52DefaultPeripherals<'_> {
             spim2: crate::spi::SPIM::new(SPIM2_BASE),
             twi1: crate::i2c::TWI::new_twi1(),
             // Default to 3.3 V VDD reference.
-            adc: crate::adc::Adc::new(3300),
+            adc: crate::adc::Adc::new(SAADC_BASE, 3300),
             nvmc: crate::nvmc::Nvmc::new(NVMC_BASE),
             clock: crate::clock::Clock::new(),
             pwm0: crate::pwm::Pwm::new(PWM0_BASE),

--- a/chips/nrf52/src/clock.rs
+++ b/chips/nrf52/src/clock.rs
@@ -28,7 +28,7 @@ use kernel::utilities::registers::{
 };
 
 register_structs! {
-    ClockRegisters {
+    pub ClockRegisters {
         (0x000 => tasks_hfclkstart: WriteOnly<u32, Control::Register>),
         (0x004 => tasks_hfclkstop: WriteOnly<u32, Control::Register>),
         (0x008 => tasks_lfclkstart: ReadWrite<u32, Control::Register>),
@@ -126,9 +126,6 @@ register_bitfields! [u32,
     ]
 ];
 
-const CLOCK_BASE: StaticRef<ClockRegisters> =
-    unsafe { StaticRef::new(0x40000000 as *const ClockRegisters) };
-
 /// Interrupt sources
 pub enum InterruptField {
     HFCLKSTARTED = 1 << 0,
@@ -167,9 +164,9 @@ pub trait ClockClient {
 
 impl Clock {
     /// Constructor
-    pub const fn new() -> Clock {
+    pub const fn new(registers: StaticRef<ClockRegisters>) -> Clock {
         Clock {
-            registers: CLOCK_BASE,
+            registers,
             client: OptionalCell::empty(),
         }
     }

--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -16,9 +16,6 @@ use kernel::utilities::StaticRef;
 use kernel::utilities::registers::interfaces::Readable;
 use kernel::utilities::registers::{ReadOnly, register_bitfields};
 
-const FICR_BASE: StaticRef<FicrRegisters> =
-    unsafe { StaticRef::new(0x10000000 as *const FicrRegisters) };
-
 /// Struct of the FICR registers
 ///
 /// Section 13.1 of <https://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.0.pdf>
@@ -26,7 +23,7 @@ const FICR_BASE: StaticRef<FicrRegisters> =
 /// The structure is identical for the data mapped here, differences start
 /// at address 0x350.
 #[repr(C)]
-struct FicrRegisters {
+pub struct FicrRegisters {
     /// Reserved
     _reserved0: [u32; 4],
     /// Code memory page size
@@ -322,10 +319,8 @@ pub struct Ficr {
 }
 
 impl Ficr {
-    pub const fn new() -> Ficr {
-        Ficr {
-            registers: FICR_BASE,
-        }
+    pub const fn new(registers: StaticRef<FicrRegisters>) -> Ficr {
+        Ficr { registers }
     }
 
     fn part(&self) -> Part {

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -15,14 +15,6 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::utilities::registers::{ReadWrite, WriteOnly, register_bitfields, register_structs};
 use nrf5x::pinmux::Pinmux;
 
-/// Uninitialized `TWI` instances.
-const INSTANCES: [StaticRef<TwiRegisters>; 2] = unsafe {
-    [
-        StaticRef::new(0x40003000 as *const TwiRegisters),
-        StaticRef::new(0x40004000 as *const TwiRegisters),
-    ]
-};
-
 /// An I2C master device.
 ///
 /// A `TWI` instance wraps a `registers::TWI` together with
@@ -44,7 +36,7 @@ pub enum Speed {
 }
 
 impl TWI<'_> {
-    const fn new(registers: StaticRef<TwiRegisters>) -> Self {
+    pub const fn new(registers: StaticRef<TwiRegisters>) -> Self {
         Self {
             registers,
             client: OptionalCell::empty(),
@@ -52,14 +44,6 @@ impl TWI<'_> {
             buf: TakeCell::empty(),
             slave_read_buf: TakeCell::empty(),
         }
-    }
-
-    pub const fn new_twi0() -> Self {
-        TWI::new(INSTANCES[0])
-    }
-
-    pub const fn new_twi1() -> Self {
-        TWI::new(INSTANCES[1])
     }
 
     /// Configures an already constructed `TWI`.

--- a/chips/nrf52/src/ieee802154_radio.rs
+++ b/chips/nrf52/src/ieee802154_radio.rs
@@ -76,9 +76,6 @@ use kernel::utilities::registers::{ReadOnly, ReadWrite, WriteOnly, register_bitf
 
 use crate::constants::TxPower;
 
-const RADIO_BASE: StaticRef<RadioRegisters> =
-    unsafe { StaticRef::new(0x40001000 as *const RadioRegisters) };
-
 const ACK_FLAG: u8 = 0b00100000;
 
 pub const IEEE802154_PAYLOAD_LENGTH: usize = 255;
@@ -105,7 +102,7 @@ pub const ACK_BUF_SIZE: usize =
 const BUF_PREFIX_SIZE: u32 = 1;
 
 #[repr(C)]
-struct RadioRegisters {
+pub struct RadioRegisters {
     /// Enable Radio in TX mode
     /// - Address: 0x000 - 0x004
     task_txen: WriteOnly<u32, Task::Register>,
@@ -717,9 +714,12 @@ impl AlarmClient for Radio<'_> {
 }
 
 impl<'a> Radio<'a> {
-    pub fn new(ack_buf: &'static mut [u8; ACK_BUF_SIZE]) -> Self {
+    pub fn new(
+        registers: StaticRef<RadioRegisters>,
+        ack_buf: &'static mut [u8; ACK_BUF_SIZE],
+    ) -> Self {
         Self {
-            registers: RADIO_BASE,
+            registers,
             rx_client: OptionalCell::empty(),
             tx_client: OptionalCell::empty(),
             config_client: OptionalCell::empty(),

--- a/chips/nrf52/src/nvmc.rs
+++ b/chips/nrf52/src/nvmc.rs
@@ -17,11 +17,8 @@ use kernel::utilities::cells::TakeCell;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{ReadOnly, ReadWrite, register_bitfields};
 
-const NVMC_BASE: StaticRef<NvmcRegisters> =
-    unsafe { StaticRef::new(0x4001E400 as *const NvmcRegisters) };
-
 #[repr(C)]
-struct NvmcRegisters {
+pub struct NvmcRegisters {
     /// Ready flag
     /// Address 0x400 - 0x404
     pub ready: ReadOnly<u32, Ready::Register>,
@@ -208,9 +205,9 @@ pub struct Nvmc {
 }
 
 impl Nvmc {
-    pub fn new() -> Self {
+    pub fn new(registers: StaticRef<NvmcRegisters>) -> Self {
         Self {
-            registers: NVMC_BASE,
+            registers,
             client: OptionalCell::empty(),
             buffer: TakeCell::empty(),
             state: Cell::new(FlashState::Ready),

--- a/chips/nrf52/src/power.rs
+++ b/chips/nrf52/src/power.rs
@@ -11,15 +11,12 @@ use kernel::utilities::registers::{
     ReadOnly, ReadWrite, WriteOnly, register_bitfields, register_structs,
 };
 
-const POWER_BASE: StaticRef<PowerRegisters> =
-    unsafe { StaticRef::new(0x40000000 as *const PowerRegisters) };
-
 // Note: only the nrf52833+ have 9 banks, but we create all of them to avoid
 // gating this code by a feature.
 const NUM_RAM_BANKS: usize = 9;
 
 register_structs! {
-    PowerRegisters {
+    pub PowerRegisters {
         (0x000 => _reserved0),
         /// Enable Constant Latency mode
         (0x078 => task_constlat: WriteOnly<u32, Task::Register>),
@@ -269,9 +266,9 @@ pub trait PowerClient {
 }
 
 impl<'a> Power<'a> {
-    pub const fn new() -> Self {
+    pub const fn new(registers: StaticRef<PowerRegisters>) -> Self {
         Power {
-            registers: POWER_BASE,
+            registers,
             usb_client: OptionalCell::empty(),
         }
     }

--- a/chips/nrf52/src/ppi.rs
+++ b/chips/nrf52/src/ppi.rs
@@ -41,11 +41,8 @@ use kernel::utilities::StaticRef;
 use kernel::utilities::registers::interfaces::Writeable;
 use kernel::utilities::registers::{FieldValue, ReadWrite, register_bitfields};
 
-const PPI_BASE: StaticRef<PpiRegisters> =
-    unsafe { StaticRef::new(0x4001F000 as *const PpiRegisters) };
-
 #[repr(C)]
-struct PpiRegisters {
+pub struct PpiRegisters {
     tasks_chg0_en: ReadWrite<u32, Control::Register>,
     tasks_chg0_dis: ReadWrite<u32, Control::Register>,
     tasks_chg1_en: ReadWrite<u32, Control::Register>,
@@ -159,10 +156,8 @@ pub struct Ppi {
 }
 
 impl Ppi {
-    pub const fn new() -> Ppi {
-        Ppi {
-            registers: PPI_BASE,
-        }
+    pub const fn new(registers: StaticRef<PpiRegisters>) -> Ppi {
+        Ppi { registers }
     }
 
     pub fn enable(&self, channels: FieldValue<u32, Channel::Register>) {

--- a/chips/nrf52/src/pwm.rs
+++ b/chips/nrf52/src/pwm.rs
@@ -11,7 +11,7 @@ use kernel::utilities::registers::interfaces::Writeable;
 use kernel::utilities::registers::{ReadWrite, WriteOnly, register_bitfields};
 
 #[repr(C)]
-struct PwmRegisters {
+pub struct PwmRegisters {
     _reserved0: [u8; 4],
     /// Stops PWM pulse generation on all channels at the end of current PWM period
     tasks_stop: WriteOnly<u32, TASK::Register>,
@@ -164,9 +164,6 @@ register_bitfields![u32,
     ]
 ];
 
-const PWM0_BASE: StaticRef<PwmRegisters> =
-    unsafe { StaticRef::new(0x4001C000 as *const PwmRegisters) };
-
 /// `DUTY_CYCLES` is a static array that must be passed to the PWM hardware.
 ///
 /// The nRF52 hardware uses this static array in memory to enable switching
@@ -180,10 +177,8 @@ pub struct Pwm {
 }
 
 impl Pwm {
-    pub const fn new() -> Pwm {
-        Pwm {
-            registers: PWM0_BASE,
-        }
+    pub const fn new(registers: StaticRef<PwmRegisters>) -> Pwm {
+        Pwm { registers }
     }
 
     fn start_pwm(

--- a/chips/nrf52/src/spi.rs
+++ b/chips/nrf52/src/spi.rs
@@ -46,16 +46,8 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::utilities::registers::{ReadWrite, WriteOnly, register_bitfields};
 use nrf5x::pinmux::Pinmux;
 
-const INSTANCES: [StaticRef<SpimRegisters>; 3] = unsafe {
-    [
-        StaticRef::new(0x40003000 as *const SpimRegisters),
-        StaticRef::new(0x40004000 as *const SpimRegisters),
-        StaticRef::new(0x40023000 as *const SpimRegisters),
-    ]
-};
-
 #[repr(C)]
-struct SpimRegisters {
+pub struct SpimRegisters {
     _reserved0: [u8; 16],                            // reserved
     tasks_start: WriteOnly<u32, TASK::Register>,     // Start SPI transaction
     tasks_stop: WriteOnly<u32, TASK::Register>,      // Stop SPI transaction
@@ -251,9 +243,9 @@ pub struct SPIM<'a> {
 }
 
 impl<'a> SPIM<'a> {
-    pub const fn new(instance: usize) -> SPIM<'a> {
+    pub const fn new(registers: StaticRef<SpimRegisters>) -> SPIM<'a> {
         SPIM {
-            registers: INSTANCES[instance],
+            registers,
             client: OptionalCell::empty(),
             chip_select: OptionalCell::empty(),
             busy: Cell::new(false),

--- a/chips/nrf52/src/uicr.rs
+++ b/chips/nrf52/src/uicr.rs
@@ -15,11 +15,8 @@ use kernel::utilities::registers::{ReadWrite, register_bitfields};
 
 use crate::gpio::Pin;
 
-const UICR_BASE: StaticRef<UicrRegisters> =
-    unsafe { StaticRef::new(0x10001200 as *const UicrRegisters) };
-
 #[repr(C)]
-struct UicrRegisters {
+pub struct UicrRegisters {
     /// Mapping of the nRESET function (see POWER chapter for details)
     /// - Address: 0x200 - 0x204
     pselreset0: ReadWrite<u32, Pselreset::Register>,
@@ -139,10 +136,8 @@ impl From<u32> for Regulator0Output {
 }
 
 impl Uicr {
-    pub const fn new() -> Uicr {
-        Uicr {
-            registers: UICR_BASE,
-        }
+    pub const fn new(registers: StaticRef<UicrRegisters>) -> Uicr {
+        Uicr { registers }
     }
 
     pub fn set_psel0_reset_pin(&self, pin: Pin) {

--- a/chips/nrf52/src/uicr.rs
+++ b/chips/nrf52/src/uicr.rs
@@ -99,8 +99,9 @@ register_bitfields! [u32,
     ]
 ];
 
-pub struct Uicr {
+pub struct Uicr<'a> {
     registers: StaticRef<UicrRegisters>,
+    ficr: &'a ficr::Ficr,
 }
 
 #[derive(Copy, Clone, PartialEq)]
@@ -135,9 +136,9 @@ impl From<u32> for Regulator0Output {
     }
 }
 
-impl Uicr {
-    pub const fn new(registers: StaticRef<UicrRegisters>) -> Uicr {
-        Uicr { registers }
+impl<'a> Uicr<'a> {
+    pub const fn new(registers: StaticRef<UicrRegisters>, ficr: &'a ficr::Ficr) -> Uicr<'a> {
+        Uicr { registers, ficr }
     }
 
     pub fn set_psel0_reset_pin(&self, pin: Pin) {
@@ -180,8 +181,7 @@ impl Uicr {
         // We need to understand the variant of this nRF52 chip to correctly
         // implement this function. Newer versions use a different value to
         // indicate disabled.
-        let factory_config = ficr::Ficr::new();
-        let disabled_val = if factory_config.has_updated_approtect_logic() {
+        let disabled_val = if self.ficr.has_updated_approtect_logic() {
             ApProtect::PALL::HWDISABLE
         } else {
             ApProtect::PALL::DISABLED
@@ -202,8 +202,7 @@ impl Uicr {
     pub fn disable_ap_protect(&self) {
         // We need to understand the variant of this nRF52 chip to correctly
         // implement this function.
-        let factory_config = ficr::Ficr::new();
-        if factory_config.has_updated_approtect_logic() {
+        if self.ficr.has_updated_approtect_logic() {
             // Newer revisions of the chip require setting the APPROTECT
             // register to `HwDisable`.
             self.registers.approtect.write(ApProtect::PALL::HWDISABLE);

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -57,19 +57,10 @@ macro_rules! internal_err {
     };
 }
 
-const CHIPINFO_BASE: StaticRef<ChipInfoRegisters> =
-    unsafe { StaticRef::new(0x10000130 as *const ChipInfoRegisters) };
-
-const USBD_BASE: StaticRef<UsbdRegisters<'static>> =
-    unsafe { StaticRef::new(0x40027000 as *const UsbdRegisters<'static>) };
-
-const USBERRATA_BASE: StaticRef<UsbErrataRegisters> =
-    unsafe { StaticRef::new(0x4006E000 as *const UsbErrataRegisters) };
-
 const NUM_ENDPOINTS: usize = 8;
 
 register_structs! {
-    ChipInfoRegisters {
+    pub ChipInfoRegisters {
         /// Undocumented register indicating the model of the chip
         (0x000 => chip_model: ReadOnly<u32, ChipModel::Register>),
         /// Undocumented register indicating the revision of the chip
@@ -78,7 +69,7 @@ register_structs! {
         (0x008 => @END),
     },
 
-    UsbErrataRegisters {
+    pub UsbErrataRegisters {
         (0x000 => _reserved0),
         /// Undocumented register - Errata 171
         (0xC00 => reg_c00: ReadWrite<u32>),
@@ -93,7 +84,7 @@ register_structs! {
 }
 
 #[repr(C)]
-struct UsbdRegisters<'a> {
+pub struct UsbdRegisters<'a> {
     _reserved1: [u32; 1],
     /// Captures the EPIN\[n\].PTR, EPIN\[n\].MAXCNT and EPIN\[n\].CONFIG
     /// registers values and enables endpoint IN not respond to traffic
@@ -713,6 +704,8 @@ impl Endpoint<'_> {
 
 pub struct Usbd<'a> {
     registers: StaticRef<UsbdRegisters<'a>>,
+    registers_chip_info: StaticRef<ChipInfoRegisters>,
+    registers_errata: StaticRef<UsbErrataRegisters>,
     state: OptionalCell<UsbState>,
     dma_pending: Cell<bool>,
     client: OptionalCell<&'a dyn hil::usb::Client<'a>>,
@@ -721,9 +714,15 @@ pub struct Usbd<'a> {
 }
 
 impl<'a> Usbd<'a> {
-    pub const fn new() -> Self {
+    pub const fn new(
+        registers: StaticRef<UsbdRegisters<'a>>,
+        registers_chip_info: StaticRef<ChipInfoRegisters>,
+        registers_errata: StaticRef<UsbErrataRegisters>,
+    ) -> Self {
         Usbd {
-            registers: USBD_BASE,
+            registers,
+            registers_chip_info,
+            registers_errata,
             client: OptionalCell::empty(),
             state: OptionalCell::new(UsbState::Disabled),
             dma_pending: Cell::new(false),
@@ -763,10 +762,14 @@ impl<'a> Usbd<'a> {
     }
 
     fn has_errata_187(&self) -> bool {
-        CHIPINFO_BASE
+        self.registers_chip_info
             .chip_model
             .matches_all(ChipModel::MODEL::NRF52840)
-            && match CHIPINFO_BASE.chip_revision.read_as_enum(ChipRevision::REV) {
+            && match self
+                .registers_chip_info
+                .chip_revision
+                .read_as_enum(ChipRevision::REV)
+            {
                 Some(ChipRevision::REV::Value::REVB)
                 | Some(ChipRevision::REV::Value::REVC)
                 | Some(ChipRevision::REV::Value::REVD)
@@ -792,12 +795,12 @@ impl<'a> Usbd<'a> {
     fn apply_errata_171(&self, val: u32) {
         if self.has_errata_171() {
             with_interrupts_disabled(|| {
-                if USBERRATA_BASE.reg_c00.get() == 0 {
-                    USBERRATA_BASE.reg_c00.set(0x9375);
-                    USBERRATA_BASE.reg_c14.set(val);
-                    USBERRATA_BASE.reg_c00.set(0x9375);
+                if self.registers_errata.reg_c00.get() == 0 {
+                    self.registers_errata.reg_c00.set(0x9375);
+                    self.registers_errata.reg_c14.set(val);
+                    self.registers_errata.reg_c00.set(0x9375);
                 } else {
-                    USBERRATA_BASE.reg_c14.set(val);
+                    self.registers_errata.reg_c14.set(val);
                 }
             });
         }
@@ -807,12 +810,12 @@ impl<'a> Usbd<'a> {
     fn apply_errata_187(&self, val: u32) {
         if self.has_errata_187() {
             with_interrupts_disabled(|| {
-                if USBERRATA_BASE.reg_c00.get() == 0 {
-                    USBERRATA_BASE.reg_c00.set(0x9375);
-                    USBERRATA_BASE.reg_d14.set(val);
-                    USBERRATA_BASE.reg_c00.set(0x9375);
+                if self.registers_errata.reg_c00.get() == 0 {
+                    self.registers_errata.reg_c00.set(0x9375);
+                    self.registers_errata.reg_d14.set(val);
+                    self.registers_errata.reg_c00.set(0x9375);
                 } else {
-                    USBERRATA_BASE.reg_d14.set(val);
+                    self.registers_errata.reg_d14.set(val);
                 }
             });
         }
@@ -910,14 +913,14 @@ impl<'a> Usbd<'a> {
         // If your chip isn't one of these, you will be alerted by these panics. You can disable
         // them but will likely need to add the relevant errata to this implementation (errata 104,
         // 154, 200).
-        let chip_model = CHIPINFO_BASE.chip_model.get();
+        let chip_model = self.registers_chip_info.chip_model.get();
         if chip_model != u32::from(ChipModel::MODEL::NRF52840) {
             panic!(
                 "USB was only tested on NRF52840. Your chip model is {}.",
                 chip_model
             );
         }
-        let chip_revision = CHIPINFO_BASE.chip_revision.extract();
+        let chip_revision = self.registers_chip_info.chip_revision.extract();
         match chip_revision.read_as_enum(ChipRevision::REV) {
             Some(ChipRevision::REV::Value::REVA) | Some(ChipRevision::REV::Value::REVB) => {
                 panic!(

--- a/chips/nrf52832/src/interrupt_service.rs
+++ b/chips/nrf52832/src/interrupt_service.rs
@@ -13,10 +13,10 @@ pub struct Nrf52832DefaultPeripherals<'a> {
     pub nrf52: Nrf52DefaultPeripherals<'a>,
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
-impl Nrf52832DefaultPeripherals<'_> {
-    pub unsafe fn new(aes_ecb_buf: &'static mut [u8; 48]) -> Self {
+impl<'a> Nrf52832DefaultPeripherals<'a> {
+    pub unsafe fn new(ficr: &'a nrf52::ficr::Ficr, aes_ecb_buf: &'static mut [u8; 48]) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(aes_ecb_buf),
+            nrf52: Nrf52DefaultPeripherals::new(ficr, aes_ecb_buf),
             gpio_port: crate::gpio::nrf52832_gpio_create(),
         }
     }

--- a/chips/nrf52833/src/interrupt_service.rs
+++ b/chips/nrf52833/src/interrupt_service.rs
@@ -15,13 +15,14 @@ pub struct Nrf52833DefaultPeripherals<'a> {
     pub ieee802154_radio: crate::ieee802154_radio::Radio<'a>,
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
-impl Nrf52833DefaultPeripherals<'_> {
+impl<'a> Nrf52833DefaultPeripherals<'a> {
     pub unsafe fn new(
+        ficr: &'a nrf52::ficr::Ficr,
         ieee802154_radio_ack_buf: &'static mut [u8; crate::ieee802154_radio::ACK_BUF_SIZE],
         aes_ecb_buf: &'static mut [u8; 48],
     ) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(aes_ecb_buf),
+            nrf52: Nrf52DefaultPeripherals::new(ficr, aes_ecb_buf),
             ieee802154_radio: crate::ieee802154_radio::Radio::new(ieee802154_radio_ack_buf),
             gpio_port: crate::gpio::nrf52833_gpio_create(),
         }

--- a/chips/nrf52833/src/interrupt_service.rs
+++ b/chips/nrf52833/src/interrupt_service.rs
@@ -3,7 +3,11 @@
 // Copyright Tock Contributors 2022.
 
 use kernel::hil::time::Alarm;
+use kernel::utilities::StaticRef;
 use nrf52::chip::Nrf52DefaultPeripherals;
+
+const RADIO_BASE: StaticRef<crate::ieee802154_radio::RadioRegisters> =
+    unsafe { StaticRef::new(0x40001000 as *const crate::ieee802154_radio::RadioRegisters) };
 
 /// This struct, when initialized, instantiates all peripheral drivers for the nrf52840.
 ///
@@ -23,7 +27,10 @@ impl<'a> Nrf52833DefaultPeripherals<'a> {
     ) -> Self {
         Self {
             nrf52: Nrf52DefaultPeripherals::new(ficr, aes_ecb_buf),
-            ieee802154_radio: crate::ieee802154_radio::Radio::new(ieee802154_radio_ack_buf),
+            ieee802154_radio: crate::ieee802154_radio::Radio::new(
+                RADIO_BASE,
+                ieee802154_radio_ack_buf,
+            ),
             gpio_port: crate::gpio::nrf52833_gpio_create(),
         }
     }

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -8,6 +8,9 @@ use kernel::hil::time::Alarm;
 use kernel::utilities::StaticRef;
 use nrf52::chip::Nrf52DefaultPeripherals;
 
+const RADIO_BASE: StaticRef<crate::ieee802154_radio::RadioRegisters> =
+    unsafe { StaticRef::new(0x40001000 as *const crate::ieee802154_radio::RadioRegisters) };
+
 const USBD_BASE: StaticRef<crate::usbd::UsbdRegisters<'static>> =
     unsafe { StaticRef::new(0x40027000 as *const crate::usbd::UsbdRegisters<'static>) };
 
@@ -53,7 +56,10 @@ impl<'a> Nrf52840DefaultPeripherals<'a> {
 
         Self {
             nrf52: nrf52_peripherals,
-            ieee802154_radio: crate::ieee802154_radio::Radio::new(ieee802154_radio_ack_buf),
+            ieee802154_radio: crate::ieee802154_radio::Radio::new(
+                RADIO_BASE,
+                ieee802154_radio_ack_buf,
+            ),
             usbd: crate::usbd::Usbd::new(USBD_BASE, USBD_CHIPINFO_BASE, USBD_USBERRATA_BASE),
             gpio_port: crate::gpio::nrf52840_gpio_create(),
         }

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -5,7 +5,17 @@
 //! Handle interrupts for nRF52840-specific peripherals
 
 use kernel::hil::time::Alarm;
+use kernel::utilities::StaticRef;
 use nrf52::chip::Nrf52DefaultPeripherals;
+
+const USBD_BASE: StaticRef<crate::usbd::UsbdRegisters<'static>> =
+    unsafe { StaticRef::new(0x40027000 as *const crate::usbd::UsbdRegisters<'static>) };
+
+const USBD_CHIPINFO_BASE: StaticRef<crate::usbd::ChipInfoRegisters> =
+    unsafe { StaticRef::new(0x10000130 as *const crate::usbd::ChipInfoRegisters) };
+
+const USBD_USBERRATA_BASE: StaticRef<crate::usbd::UsbErrataRegisters> =
+    unsafe { StaticRef::new(0x4006E000 as *const crate::usbd::UsbErrataRegisters) };
 
 /// This struct, when initialized, instantiates all peripheral drivers for the nrf52840.
 ///
@@ -43,7 +53,7 @@ impl Nrf52840DefaultPeripherals<'_> {
         Self {
             nrf52: nrf52_peripherals,
             ieee802154_radio: crate::ieee802154_radio::Radio::new(ieee802154_radio_ack_buf),
-            usbd: crate::usbd::Usbd::new(),
+            usbd: crate::usbd::Usbd::new(USBD_BASE, USBD_CHIPINFO_BASE, USBD_USBERRATA_BASE),
             gpio_port: crate::gpio::nrf52840_gpio_create(),
         }
     }

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -30,7 +30,7 @@ pub struct Nrf52840DefaultPeripherals<'a> {
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
 
-impl Nrf52840DefaultPeripherals<'_> {
+impl<'a> Nrf52840DefaultPeripherals<'a> {
     /// Create default peripherals for the nRF52840 microcontroller.
     ///
     /// # Safety
@@ -44,11 +44,12 @@ impl Nrf52840DefaultPeripherals<'_> {
     /// - There must not be any other code that accesses the DMA buffer and
     ///   length registers of the DMA-enabled peripherals.
     pub unsafe fn new(
+        ficr: &'a nrf52::ficr::Ficr,
         ieee802154_radio_ack_buf: &'static mut [u8; crate::ieee802154_radio::ACK_BUF_SIZE],
         aes_ecb_buf: &'static mut [u8; 48],
     ) -> Self {
         // SAFETY: See function-level doc.
-        let nrf52_peripherals = unsafe { Nrf52DefaultPeripherals::new(aes_ecb_buf) };
+        let nrf52_peripherals = unsafe { Nrf52DefaultPeripherals::new(ficr, aes_ecb_buf) };
 
         Self {
             nrf52: nrf52_peripherals,


### PR DESCRIPTION
### Pull Request Overview

This is part of my quest to move the nrf52 crate to be mostly safe, and only have the necessary unsafe code in dedicated unsafe crates. In this part of the series, this moves all† of the of the `StaticRef` constructors to chip.rs. This removes the unsafe code from the actual driver, setting the driver to be in a safe crate.

For many peripherals, this is straightforward: move the static ref to chip.rs, add the register static ref as an argument to new(), update default peripherals.

For some, this is a lot more involved. Things like UICR, APProtect, and FICR are used in various places in board files. I updated these to use the same format as any other peripheral. Also, UICR and APProtect use FICR, so that is now constructed in the board and passed in so a reference can be given to uicr and approtect.

Peripherals like USB and 15.4 radio are only used in specific variants, and so this moves those static refs to those chips.




† I didn't move uart because that is being changed in a different PR.

### Testing Strategy

travis


### TODO or Help Wanted

This is but a step on a long journey. By doing this step in its own PR, the change to reorg crates into safe/unsafe will be much smaller and easier to reason about.


### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

I _almost_ made it through this myself. Nearly everything I did manually, but the changes to FICR were too much. I did the changes to chips/nrf52 in the commit "chips: nrf52: move ficr unsafe static ref", and had claude fixup all the changes in all of the nrf52 boards.
