### PR TITLE
Ci/tockbot update user lists

### DIFF
--- a/tools/ci/tockbot/maint_nightly.yaml
+++ b/tools/ci/tockbot/maint_nightly.yaml
@@ -4,23 +4,23 @@
 
 _anchors:
   core_wg_users: &core_wg_users
-    - hudson-ayers
+    - alevy
     - bradjc
     - brghena
-    - phil-levis
-    - alevy
-    - ppannuto
-    - lschuermann
+    - hudson-ayers
     - jrvanwhy
+    - lschuermann
+    - phil-levis
+    - ppannuto
 
   active_reviewers: &active_reviewers
+    - alevy
     - alexandruradovici
-    - hudson-ayers
     - bradjc
     - brghena
-    - alevy
-    - lschuermann
+    - hudson-ayers
     - jrvanwhy
+    - lschuermann
 
 repo:
   owner: tock

--- a/tools/ci/tockbot/maint_nightly.yaml
+++ b/tools/ci/tockbot/maint_nightly.yaml
@@ -15,13 +15,13 @@ _anchors:
     - ppannuto
 
   active_reviewers: &active_reviewers
-    - alevy
     - alexandruradovici
     - bradjc
     - brghena
     - hudson-ayers
     - jrvanwhy
     - lschuermann
+    - ppannuto
 
 repo:
   owner: tock

--- a/tools/ci/tockbot/maint_nightly.yaml
+++ b/tools/ci/tockbot/maint_nightly.yaml
@@ -5,6 +5,7 @@
 _anchors:
   core_wg_users: &core_wg_users
     - alevy
+    - alexandruradovici
     - bradjc
     - brghena
     - hudson-ayers


### PR DESCRIPTION
### Pull Request Overview

This updates the user lists for tockbot. It adds @alexandruradovici to core (which happened a while ago, just missed the metadata update here); it then adds me and drops @alevy from the active review list to reflect our current leave statuses.

The diff looks bigger b/c the first commit alpha-orders the list for maintainability.

### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

<!-- Include details of AI use here, if you used any -->
