### PR TITLE
[`PanicWriter`] chips: apollo3: update to PanicWriter

### DIFF
--- a/boards/apollo3/lora_things_plus/src/io.rs
+++ b/boards/apollo3/lora_things_plus/src/io.rs
@@ -2,34 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::hil::led;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer {};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let uart = apollo3::uart::Uart::new_uart_0(); // Aliases memory for uart0. Okay bc we are panicking.
-        uart.transmit_sync(buf);
-        buf.len()
-    }
-}
+use apollo3::uart::{UART0_BASE, Uart, UartPanicWriterConfig};
 
 /// Panic handler.
 #[panic_handler]
@@ -42,11 +21,19 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         apollo3::gpio::Pin::Pin26,
     );
     let led = &mut led::LedLow::new(led_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    debug::panic::<_, Uart, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            registers: UART0_BASE,
+            params: Parameters {
+                baud_rate: 115200,
+                width: Width::Eight,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+            },
+        },
         info,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/apollo3/redboard_artemis_atp/src/io.rs
+++ b/boards/apollo3/redboard_artemis_atp/src/io.rs
@@ -2,34 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::hil::led;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer {};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let uart = apollo3::uart::Uart::new_uart_0(); // Aliases memory for uart0. Okay bc we are panicking.
-        uart.transmit_sync(buf);
-        buf.len()
-    }
-}
+use apollo3::uart::{UART0_BASE, Uart, UartPanicWriterConfig};
 
 /// Panic handler.
 #[panic_handler]
@@ -42,11 +21,19 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         apollo3::gpio::Pin::Pin19,
     );
     let led = &mut led::LedLow::new(led_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    debug::panic::<_, Uart, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            registers: UART0_BASE,
+            params: Parameters {
+                baud_rate: 115200,
+                width: Width::Eight,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+            },
+        },
         info,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/boards/apollo3/redboard_artemis_nano/src/io.rs
+++ b/boards/apollo3/redboard_artemis_nano/src/io.rs
@@ -2,34 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::ptr::addr_of_mut;
 
 use kernel::debug;
 use kernel::hil::led;
-use kernel::utilities::io_write::IoWrite;
+use kernel::hil::uart::{Parameters, Parity, StopBits, Width};
 
-/// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {}
-
-/// Global static for debug writer
-pub static mut WRITER: Writer = Writer {};
-
-impl Write for Writer {
-    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        self.write(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl IoWrite for Writer {
-    fn write(&mut self, buf: &[u8]) -> usize {
-        let uart = apollo3::uart::Uart::new_uart_0(); // Aliases memory for uart0. Okay bc we are panicking.
-        uart.transmit_sync(buf);
-        buf.len()
-    }
-}
+use apollo3::uart::{UART0_BASE, Uart, UartPanicWriterConfig};
 
 /// Panic handler.
 #[panic_handler]
@@ -42,11 +21,19 @@ pub unsafe fn panic_fmt(info: &PanicInfo) -> ! {
         apollo3::gpio::Pin::Pin19,
     );
     let led = &mut led::LedLow::new(led_pin);
-    let writer = &mut *addr_of_mut!(WRITER);
 
-    debug::panic_old(
+    debug::panic::<_, Uart, _, _>(
         &mut [led],
-        writer,
+        UartPanicWriterConfig {
+            registers: UART0_BASE,
+            params: Parameters {
+                baud_rate: 115200,
+                width: Width::Eight,
+                stop_bits: StopBits::One,
+                parity: Parity::None,
+                hw_flow_control: false,
+            },
+        },
         info,
         &cortexm4::support::nop,
         crate::PANIC_RESOURCES.get(),

--- a/chips/apollo3/src/uart.rs
+++ b/chips/apollo3/src/uart.rs
@@ -12,10 +12,11 @@ use kernel::hil::uart;
 use kernel::utilities::StaticRef;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
+use kernel::utilities::io_write::IoWrite;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{ReadWrite, register_bitfields, register_structs};
 
-const UART0_BASE: StaticRef<UartRegisters> =
+pub const UART0_BASE: StaticRef<UartRegisters> =
     unsafe { StaticRef::new(0x4001_C000 as *const UartRegisters) };
 
 pub const UART1_BASE: StaticRef<UartRegisters> =
@@ -185,6 +186,21 @@ pub struct UartParams {
 }
 
 impl Uart<'_> {
+    pub fn new(base: StaticRef<UartRegisters>) -> Self {
+        Self {
+            registers: base,
+            clock_frequency: 24_000_000,
+            tx_client: OptionalCell::empty(),
+            rx_client: OptionalCell::empty(),
+            tx_buffer: TakeCell::empty(),
+            tx_len: Cell::new(0),
+            tx_index: Cell::new(0),
+            rx_buffer: TakeCell::empty(),
+            rx_len: Cell::new(0),
+            rx_index: Cell::new(0),
+        }
+    }
+
     // unsafe bc of UART0_BASE usage, called twice would alias location
     pub fn new_uart_0() -> Self {
         Self {
@@ -484,5 +500,62 @@ impl<'a> hil::uart::Receive<'a> for Uart<'a> {
 
     fn receive_word(&self) -> Result<(), ErrorCode> {
         Err(ErrorCode::FAIL)
+    }
+}
+
+/// A synchronous writer for the apollo3 useful for panics.
+///
+/// For boards that want to use the UART to display panic messages, this
+/// provides an implementation of
+/// [`PanicWriter`](kernel::platform::chip::PanicWriter) with synchronous
+/// output.
+///
+/// This is only to be used by panic messages and is not used within the normal
+/// operation of the Tock kernel.
+struct UartPanicWriter<'a> {
+    uart: Uart<'a>,
+}
+
+impl IoWrite for UartPanicWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.uart.transmit_sync(buf);
+        buf.len()
+    }
+}
+
+impl core::fmt::Write for UartPanicWriter<'_> {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+/// Configuration for the synchronous UART panic writer.
+///
+/// This captures everything needed to setup the UART for panic display, even
+/// if the normal kernel had initialized it differently.
+pub struct UartPanicWriterConfig {
+    pub registers: StaticRef<UartRegisters>,
+    pub params: hil::uart::Parameters,
+}
+
+impl kernel::platform::chip::PanicWriter for Uart<'_> {
+    type Config = UartPanicWriterConfig;
+
+    fn create_panic_writer(
+        config: Self::Config,
+        _panic: &core::panic::PanicInfo,
+    ) -> impl IoWrite + core::fmt::Write {
+        use hil::uart::Configure as _;
+
+        let uart = Uart::new(config.registers);
+
+        // Configure the UART correctly for panics.
+        let _ = uart.configure(config.params);
+
+        // Enable the UART for transmission.
+        uart.registers.cr.modify(CR::UARTEN::SET + CR::TXE::SET);
+
+        UartPanicWriter { uart }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This ports the apollo3 chip to PanicWriter and removes the `static mut` from the boards' io.rs files.


### Testing Strategy

Just compiling.


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

Claude did the original conversion in #4831. I pulled out just the one board and updated with the recent changes to PanicWriter. I removed an old todo comment and the changes look straightforward.
