### PR TITLE
RFC: Add `dup_driver_num()` function

### DIFF
--- a/capsules/core/src/driver.rs
+++ b/capsules/core/src/driver.rs
@@ -7,6 +7,32 @@
 use enum_primitive::cast::FromPrimitive;
 use enum_primitive::enum_from_primitive;
 
+/// Create a `DRIVER_NUM` for a second (or third, etc.) instance of a
+/// [`SyscallDriver`](kernel::syscall::SyscallDriver).
+///
+/// Creating additional driver numbers for known drivers uses the second most
+/// significant nibble of the 32-bit driver number. This allows creating up to
+/// 15 additional driver numbers for the same driver. The original driver of
+/// course has 0 in this field.
+///
+/// The format is like this:
+///
+/// ```text
+/// 32         28         24                                        0
+///  ┌──────────┬──────────┬────────────────────────────────────────┐
+///  │ 0        │ Instance │ Driver Number                          │
+///  │          │ Number   │                                        │
+///  └──────────┴──────────┴────────────────────────────────────────┘
+/// ```
+pub const fn dup_driver_num(driver_num: usize, instance_num: usize) -> usize {
+    assert!(
+        instance_num < 16,
+        "This mechanism only supports up to 15 additional driver numbers."
+    );
+
+    (instance_num << 24) | driver_num
+}
+
 enum_from_primitive! {
 #[derive(Debug, PartialEq)]
 // syscall driver numbers


### PR DESCRIPTION


### Pull Request Overview

This is a const helper function that helps create a second (or third, etc.) driver number based on an existing driver number. It isn't too common we want this, but this makes an attempt at having some standard way to instantiate a second copy of the same capsule on a board.

I chose the 2nd nibble a bit at random. It avoids conflicting with our upper bit is 1 for private/out-of-tree drivers policy. It allows up to 16 driver numbers for the same driver, which seems like plenty. It also gives us plenty of room to create new base driver number groupings.

I wanted this to be able to run multiple serial ports and consoles on the nrf52840dk (one using the normal "FTDI" chip over USB, and second using our on-tock CDC-over-USB stack).


### Testing Strategy

I used this in testing my second console. But, the function is pretty simple.


### TODO or Help Wanted

Thoughts? Do we want a helper for this? Is this the right format for creating second/third/etc versions of drivers?


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [ ] No documentation updates are required.

We might want to document this, depending on the sentiment. Is this a useful policy to publicize? Or just something we continue to do in an ad-hoc way?

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

<!-- Include details of AI use here, if you used any -->
