### PR TITLE
boards: config: add CDC test for nrf52840dk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,6 +1051,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "nrf52840dk-test-usb-cdc"
+version = "0.2.3-dev"
+dependencies = [
+ "capsules-core",
+ "capsules-extra",
+ "capsules-system",
+ "components",
+ "cortexm4",
+ "kernel",
+ "nrf52840",
+ "nrf52840dk-test-base",
+ "nrf52_components",
+ "segger",
+ "tock_build_scripts",
+]
+
+[[package]]
 name = "nrf52840dk-thread-tutorial"
 version = "0.2.3-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ members = [
     "boards/configurations/nrf52840dk/nrf52840dk-test-kernel",
     "boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load",
     "boards/configurations/nrf52840dk/nrf52840dk-test-sha256",
+    "boards/configurations/nrf52840dk/nrf52840dk-test-usb-cdc",
     "boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load",
     "boards/configurations/qemu_rv64_virt/qemu_rv64_virt-test-ci",
     "boards/tutorials/nrf52840dk-root-of-trust-tutorial",

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-usb-cdc/Cargo.toml
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-usb-cdc/Cargo.toml
@@ -1,0 +1,30 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+[package]
+name = "nrf52840dk-test-usb-cdc"
+version.workspace = true
+authors.workspace = true
+build = "../../../build.rs"
+edition.workspace = true
+
+[dependencies]
+nrf52840dk-test-base = { path = "../nrf52840dk-test-base" }
+
+components = { path = "../../../components" }
+cortexm4 = { path = "../../../../arch/cortex-m4" }
+kernel = { path = "../../../../kernel" }
+nrf52840 = { path = "../../../../chips/nrf52840" }
+segger = { path = "../../../../chips/segger" }
+nrf52_components = { path = "../../../nordic/nrf52_components" }
+
+capsules-core = { path = "../../../../capsules/core" }
+capsules-extra = { path = "../../../../capsules/extra" }
+capsules-system = { path = "../../../../capsules/system" }
+
+[build-dependencies]
+tock_build_scripts = { path = "../../../build_scripts" }
+
+[lints]
+workspace = true

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-usb-cdc/Makefile
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-usb-cdc/Makefile
@@ -1,0 +1,6 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+include ../../../Makefile.common
+include ../nrf52840dk.mk

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-usb-cdc/README.md
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-usb-cdc/README.md
@@ -1,0 +1,11 @@
+nRF52840-DK USB CDC Console Test Board
+===================================
+
+This is a test kernel for the nRF52840DK that, in addition to the standard
+UART console provided by `nrf52840dk-test-base`, sets up the nRF52840's USB
+controller and the CDC-ACM stack to expose a second, independent serial
+console to userspace over USB.
+
+The second console is at driver number `CONSOLE2_DRIVER_NUM | 0x0100_0000`.
+
+This is for simpler testing of the CDC over USB stack.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-usb-cdc/layout.ld
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-usb-cdc/layout.ld
@@ -1,0 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2026.                                  */
+
+INCLUDE ../../../nordic/nrf52840_chip_layout.ld
+INCLUDE tock_kernel_layout.ld

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-usb-cdc/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-usb-cdc/src/main.rs
@@ -1,0 +1,203 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! Tock kernel for the Nordic Semiconductor nRF52840 development kit (DK)
+//! with a second, USB CDC-ACM based serial console.
+
+#![no_std]
+#![no_main]
+#![deny(missing_docs)]
+
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil::usb::Client;
+use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::static_init;
+
+type ChipHw = nrf52840dk_test_base_lib::ChipHw;
+
+type Console2Driver = components::console::ConsoleComponentType;
+
+const fn dup_driver_num(driver_num: usize, instance: usize) -> usize {
+    (instance << 24) | driver_num
+}
+
+const CONSOLE2_DRIVER_NUM: usize = dup_driver_num(capsules_core::console::DRIVER_NUM, 1);
+
+/// Supported drivers by the platform
+pub struct Platform {
+    base: nrf52840dk_test_base_lib::Platform,
+    console2: &'static Console2Driver,
+}
+
+impl SyscallDriverLookup for Platform {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
+    {
+        match driver_num {
+            CONSOLE2_DRIVER_NUM => f(Some(self.console2)),
+
+            _ => self.base.with_driver(driver_num, f),
+        }
+    }
+}
+
+impl KernelResources<ChipHw> for Platform {
+    type SyscallDriverLookup = Self;
+    type SyscallFilter =
+        <nrf52840dk_test_base_lib::Platform as KernelResources<ChipHw>>::SyscallFilter;
+    type ProcessFault =
+        <nrf52840dk_test_base_lib::Platform as KernelResources<ChipHw>>::ProcessFault;
+    type Scheduler = <nrf52840dk_test_base_lib::Platform as KernelResources<ChipHw>>::Scheduler;
+    type SchedulerTimer =
+        <nrf52840dk_test_base_lib::Platform as KernelResources<ChipHw>>::SchedulerTimer;
+    type WatchDog = <nrf52840dk_test_base_lib::Platform as KernelResources<ChipHw>>::WatchDog;
+    type ContextSwitchCallback =
+        <nrf52840dk_test_base_lib::Platform as KernelResources<ChipHw>>::ContextSwitchCallback;
+
+    fn syscall_driver_lookup(&self) -> &Self::SyscallDriverLookup {
+        self
+    }
+    fn syscall_filter(&self) -> &Self::SyscallFilter {
+        self.base.syscall_filter()
+    }
+    fn process_fault(&self) -> &Self::ProcessFault {
+        self.base.process_fault()
+    }
+    fn scheduler(&self) -> &Self::Scheduler {
+        self.base.scheduler()
+    }
+    fn scheduler_timer(&self) -> &Self::SchedulerTimer {
+        self.base.scheduler_timer()
+    }
+    fn watchdog(&self) -> &Self::WatchDog {
+        self.base.watchdog()
+    }
+    fn context_switch_callback(&self) -> &Self::ContextSwitchCallback {
+        self.base.context_switch_callback()
+    }
+}
+
+/// Main function called after RAM initialized.
+#[no_mangle]
+pub unsafe fn main() {
+    let (board_kernel, base_platform, chip, nrf52840_peripherals, _mux_uart, mux_alarm) =
+        nrf52840dk_test_base_lib::start();
+
+    //--------------------------------------------------------------------------
+    // USB CDC-ACM (SECOND SERIAL CONSOLE)
+    //--------------------------------------------------------------------------
+
+    // Create the strings we include in the USB descriptor. We use the
+    // hardcoded DEVICEADDR register on the nRF52 to set the serial number.
+    let ficr = nrf52840::ficr::Ficr::new();
+    let serial_number_buf = static_init!([u8; 17], [0; 17]);
+    let serial_number_string: &'static str = ficr.address_str(serial_number_buf);
+    let strings = static_init!(
+        [&str; 3],
+        [
+            "Tock",                // Manufacturer
+            "nRF52840DK - TockOS", // Product
+            serial_number_string,  // Serial number
+        ]
+    );
+
+    let cdc = components::cdc::CdcAcmComponent::new(
+        &nrf52840_peripherals.usbd,
+        capsules_extra::usb::cdc::MAX_CTRL_PACKET_SIZE_NRF52840,
+        0x2341,
+        0x005a,
+        strings,
+        mux_alarm,
+        None,
+    )
+    .finalize(components::cdc_acm_component_static!(
+        nrf52840::usbd::Usbd,
+        nrf52840::rtc::Rtc
+    ));
+
+    // Virtualize the CDC-ACM connection so it can be used as a UART for the
+    // second console, independent of the UART console set up by
+    // `nrf52840dk-test-base`.
+    let mux_uart2 = components::console::UartMuxComponent::new(cdc, 115200)
+        .finalize(components::uart_mux_component_static!());
+
+    // Setup a second serial console for userspace, this time over the
+    // USB CDC-ACM channel, registered at a different driver number than the
+    // standard UART console.
+    let console2 = components::console::ConsoleComponent::new(
+        board_kernel,
+        CONSOLE2_DRIVER_NUM,
+        mux_uart2,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::console_component_static!());
+
+    // Configure the USB stack to enable the CDC-ACM serial port.
+    cdc.enable();
+    cdc.attach();
+
+    //--------------------------------------------------------------------------
+    // PLATFORM
+    //--------------------------------------------------------------------------
+
+    let platform = Platform {
+        base: base_platform,
+        console2,
+    };
+
+    //--------------------------------------------------------------------------
+    // PROCESS LOADING
+    //--------------------------------------------------------------------------
+
+    // These symbols are defined in the standard Tock linker script.
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+        /// End of the ROM region containing app images.
+        static _eapps: u8;
+        /// Beginning of the RAM region for app memory.
+        static mut _sappmem: u8;
+        /// End of the RAM region for app memory.
+        static _eappmem: u8;
+    }
+
+    let app_flash = core::slice::from_raw_parts(
+        core::ptr::addr_of!(_sapps),
+        core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
+    );
+    let app_memory = core::slice::from_raw_parts_mut(
+        core::ptr::addr_of_mut!(_sappmem),
+        core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
+    );
+
+    let process_management_capability =
+        create_capability!(capabilities::ProcessManagementCapability);
+    kernel::process::load_processes(
+        board_kernel,
+        chip,
+        app_flash,
+        app_memory,
+        &nrf52840dk_test_base_lib::FAULT_RESPONSE,
+        &process_management_capability,
+    )
+    .unwrap_or_else(|err| {
+        kernel::debug!("Error loading processes!");
+        kernel::debug!("{:?}", err);
+    });
+
+    //--------------------------------------------------------------------------
+    // PLATFORM SETUP, SCHEDULER, AND START KERNEL LOOP
+    //--------------------------------------------------------------------------
+
+    let main_loop_capability = create_capability!(kernel::capabilities::MainLoopCapability);
+    board_kernel.kernel_loop(
+        &platform,
+        chip,
+        None::<&kernel::ipc::IPC<0>>,
+        &main_loop_capability,
+    );
+}


### PR DESCRIPTION
### Pull Request Overview

Inspired by the work on the CDC stack, I thought it would be helpful to have a convenient way to test the CDC stack with a standard board. What is nice about using the nRF52840dk is that it doesn't _rely_ on the CDC, so it is still easy to see if things are working or debug if needed.


### Testing Strategy

I wrote a test app in libtock-c and verified I can send data from userspace over the second USB header on the nRF52840dk.


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

I had claude generate the board. I modified the driver number selection. The changes are pretty rote and copied from other nrf52 boards that do use the CDC stack.
