### PR TITLE
capsules: PWM: fix duty cycle calculation

### DIFF
--- a/capsules/extra/src/pwm.rs
+++ b/capsules/extra/src/pwm.rs
@@ -112,10 +112,25 @@ impl<const NUM_PINS: usize> SyscallDriver for Pwm<'_, NUM_PINS> {
                         // Duty cycle is represented as a 4 digit number, so we divide by 10000 to get the percentage of the max duty cycle.
                         // e.g.: a duty cycle of 60.5% is represented as 6050, so the actual value of the duty cycle is
                         // 6050 * max_duty_cycle / 10000 = 0.605 * max_duty_cycle
+                        //
+                        // However, the max duty cycle might be large enough to overflow a u32, so
+                        // we cast to u64 to do the calculation.
+                        const fn ratio_max_duty_cycle(
+                            duty_cycle_hundredths: usize,
+                            max_cycles: usize,
+                        ) -> usize {
+                            let cycles_hundredths: u64 =
+                                duty_cycle_hundredths as u64 * max_cycles as u64;
+                            (cycles_hundredths / 10000) as usize
+                        }
+
                         self.pwm_pins[pin]
                             .start(
                                 frequency_hz,
-                                duty_cycle * self.pwm_pins[pin].get_maximum_duty_cycle() / 10000,
+                                ratio_max_duty_cycle(
+                                    duty_cycle,
+                                    self.pwm_pins[pin].get_maximum_duty_cycle(),
+                                ),
                             )
                             .into()
                     }


### PR DESCRIPTION
### Pull Request Overview

The conversion from 1/100s of a percent duty cycle to a number of cycles based on the actual PWM's hardware can overflow in 32-bit numbers. For example, on the nRF52 the max duty cycle is 5333333 cycles. So to set an 80.05% duty cycle, for example, requires multiplying 8005 * 5333333, which is 9.9 times larger than 2^32. So, this converts the arithmetic to u64 numbers.


### Testing Strategy

Running PWM on the nrf52 and seeing that pulsing LEDs actually works and that the duty cycle conversions make sense.


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

<!-- Include details of AI use here, if you used any -->
