### PR TITLE
chips: nRF52: Add DMA Manager to PWM

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -277,6 +277,7 @@ unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let pwm_buf = static_init!([u16; 4], [0; 4]);
     let ficr = static_init!(
         nrf52840::ficr::Ficr,
         nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
@@ -285,7 +286,7 @@ unsafe fn start() -> (
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf, pwm_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load/src/main.rs
@@ -253,6 +253,7 @@ unsafe fn start() -> (
         [0; nrf52833::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let pwm_buf = static_init!([u16; 4], [0; 4]);
     let ficr = static_init!(
         nrf52833::ficr::Ficr,
         nrf52833::ficr::Ficr::new(nrf52833::chip::FICR_BASE)
@@ -260,7 +261,7 @@ unsafe fn start() -> (
     // Initialize chip peripheral drivers
     let nrf52833_peripherals = static_init!(
         Nrf52833DefaultPeripherals,
-        Nrf52833DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52833DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf, pwm_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
@@ -94,6 +94,7 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let pwm_buf = static_init!([u16; 4], [0; 4]);
     let ficr = static_init!(
         nrf52840::ficr::Ficr,
         nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
@@ -101,7 +102,7 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf, pwm_buf)
     );
 
     nrf52840_peripherals

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load/src/main.rs
@@ -130,6 +130,7 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let pwm_buf = static_init!([u16; 4], [0; 4]);
     let ficr = static_init!(
         nrf52840::ficr::Ficr,
         nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
@@ -137,7 +138,7 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf, pwm_buf)
     );
 
     nrf52840_peripherals

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-kernel/src/main.rs
@@ -119,6 +119,7 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let pwm_buf = static_init!([u16; 4], [0; 4]);
     let ficr = static_init!(
         nrf52840::ficr::Ficr,
         nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
@@ -126,7 +127,7 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf, pwm_buf)
     );
 
     nrf52840_peripherals

--- a/boards/makepython-nrf52840/src/main.rs
+++ b/boards/makepython-nrf52840/src/main.rs
@@ -250,6 +250,7 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let pwm_buf = static_init!([u16; 4], [0; 4]);
     let ficr = static_init!(
         nrf52840::ficr::Ficr,
         nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
@@ -258,7 +259,7 @@ pub unsafe fn start() -> (
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf, pwm_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -236,6 +236,7 @@ unsafe fn start() -> (
         [0; nrf52833::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let pwm_buf = static_init!([u16; 4], [0; 4]);
     let ficr = static_init!(
         nrf52833::ficr::Ficr,
         nrf52833::ficr::Ficr::new(nrf52833::chip::FICR_BASE)
@@ -244,7 +245,7 @@ unsafe fn start() -> (
     // Initialize chip peripheral drivers
     let nrf52833_peripherals = static_init!(
         Nrf52833DefaultPeripherals,
-        Nrf52833DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52833DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf, pwm_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -260,6 +260,7 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let pwm_buf = static_init!([u16; 4], [0; 4]);
     let ficr = static_init!(
         nrf52840::ficr::Ficr,
         nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
@@ -268,7 +269,7 @@ pub unsafe fn start() -> (
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf, pwm_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nano33ble_rev2/src/main.rs
+++ b/boards/nano33ble_rev2/src/main.rs
@@ -266,6 +266,7 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let pwm_buf = static_init!([u16; 4], [0; 4]);
     let ficr = static_init!(
         nrf52840::ficr::Ficr,
         nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
@@ -274,7 +275,7 @@ pub unsafe fn start() -> (
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf, pwm_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -211,6 +211,7 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let pwm_buf = static_init!([u16; 4], [0; 4]);
     let ficr = static_init!(
         nrf52840::ficr::Ficr,
         nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
@@ -218,7 +219,7 @@ pub unsafe fn start() -> (
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf, pwm_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/nordic/nrf52840dk/src/lib.rs
+++ b/boards/nordic/nrf52840dk/src/lib.rs
@@ -436,6 +436,7 @@ pub unsafe fn start_no_pconsole() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let pwm_buf = static_init!([u16; 4], [0; 4]);
     let ficr = static_init!(
         nrf52840::ficr::Ficr,
         nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
@@ -446,7 +447,7 @@ pub unsafe fn start_no_pconsole() -> (
     let nrf52840_peripherals = unsafe {
         static_init!(
             Nrf52840DefaultPeripherals,
-            Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
+            Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf, pwm_buf)
         )
     };
 

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -257,13 +257,14 @@ pub unsafe fn start() -> (
         );
 
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let pwm_buf = static_init!([u16; 4], [0; 4]);
     let ficr = static_init!(
         nrf52832::ficr::Ficr,
         nrf52832::ficr::Ficr::new(nrf52832::chip::FICR_BASE)
     );
     let nrf52832_peripherals = static_init!(
         Nrf52832DefaultPeripherals,
-        Nrf52832DefaultPeripherals::new(ficr, aes_ecb_buf)
+        Nrf52832DefaultPeripherals::new(ficr, aes_ecb_buf, pwm_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -196,6 +196,7 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let pwm_buf = static_init!([u16; 4], [0; 4]);
     let ficr = static_init!(
         nrf52840::ficr::Ficr,
         nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
@@ -204,7 +205,7 @@ unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'stati
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf, pwm_buf)
     );
 
     nrf52840_peripherals

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -213,6 +213,7 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let pwm_buf = static_init!([u16; 4], [0; 4]);
     let ficr = static_init!(
         nrf52840::ficr::Ficr,
         nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
@@ -221,7 +222,7 @@ pub unsafe fn start() -> (
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf, pwm_buf)
     );
 
     // set up circular peripheral dependencies

--- a/boards/wm1110dev/src/main.rs
+++ b/boards/wm1110dev/src/main.rs
@@ -216,6 +216,7 @@ pub unsafe fn start() -> (
         [0; nrf52840::ieee802154_radio::ACK_BUF_SIZE]
     );
     let aes_ecb_buf = static_init!([u8; 48], [0; 48]);
+    let pwm_buf = static_init!([u16; 4], [0; 4]);
     let ficr = static_init!(
         nrf52840::ficr::Ficr,
         nrf52840::ficr::Ficr::new(nrf52840::chip::FICR_BASE)
@@ -224,7 +225,7 @@ pub unsafe fn start() -> (
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf)
+        Nrf52840DefaultPeripherals::new(ficr, ieee802154_ack_buf, aes_ecb_buf, pwm_buf)
     );
 
     // set up circular peripheral dependencies

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -131,12 +131,19 @@ impl<'a> Nrf52DefaultPeripherals<'a> {
     ///   drivers.
     /// - There must not be any other code that accesses the DMA buffer and
     ///   length registers of the DMA-enabled peripherals.
-    pub unsafe fn new(ficr: &'a crate::ficr::Ficr, aes_ecb_buffer: &'static mut [u8; 48]) -> Self {
+    pub unsafe fn new(
+        ficr: &'a crate::ficr::Ficr,
+        aes_ecb_buffer: &'static mut [u8; 48],
+        pwm_buffer: &'static mut [u16; 4],
+    ) -> Self {
         // SAFETY: See function-level doc.
         let aes_registers = unsafe { crate::aes::AesEcbRegistersManager::new(AESECB_BASE) };
 
         // SAFETY: See function-level doc.
         let uarte0_registers = unsafe { crate::uart::UarteRegistersManager::new_uarte0() };
+
+        // SAFETY: See function-level doc.
+        let pwm0_registers = unsafe { crate::pwm::PwmRegistersManager::new(PWM0_BASE, pwm_buffer) };
 
         Self {
             acomp: crate::acomp::Comparator::new(COMP_BASE),
@@ -157,7 +164,7 @@ impl<'a> Nrf52DefaultPeripherals<'a> {
             adc: crate::adc::Adc::new(SAADC_BASE, 3300),
             nvmc: crate::nvmc::Nvmc::new(NVMC_BASE),
             clock: crate::clock::Clock::new(CLOCK_BASE),
-            pwm0: crate::pwm::Pwm::new(PWM0_BASE),
+            pwm0: crate::pwm::Pwm::new(pwm0_registers),
             uicr: crate::uicr::Uicr::new(UICR_BASE, ficr),
             approtect: crate::approtect::Approtect::new(APPROTECT_BASE, ficr),
             ficr,

--- a/chips/nrf52/src/pwm.rs
+++ b/chips/nrf52/src/pwm.rs
@@ -7,6 +7,8 @@
 use kernel::ErrorCode;
 use kernel::hil;
 use kernel::utilities::StaticRef;
+use kernel::utilities::cells::MapCell;
+use kernel::utilities::dma_slice::DmaSliceMut;
 use kernel::utilities::registers::interfaces::Writeable;
 use kernel::utilities::registers::{ReadWrite, WriteOnly, register_bitfields, register_structs};
 
@@ -168,20 +170,115 @@ register_bitfields![u32,
     ]
 ];
 
-/// `DUTY_CYCLES` is a static array that must be passed to the PWM hardware.
-///
-/// The nRF52 hardware uses this static array in memory to enable switching
-/// between multiple duty cycles automatically while generating the PWM output.
-/// This isn't ideal from a Rust perspective, but the peripheral hardware must
-/// be passed a pointer.
-static mut DUTY_CYCLES: [u16; 4] = [0; 4];
+/// Wrapper for managing MMIO for the PWM peripheral.
+pub struct PwmRegistersManager {
+    /// MMIO registers for the PWM peripheral.
+    registers: StaticRef<PwmRegisters>,
+    /// Buffer that describes the PWM configuration.
+    duty_cycles: MapCell<&'static mut [u16]>,
+    /// Holding place for the duty cycle buffer while held by DMA.
+    duty_cycles_dma: MapCell<DmaSliceMut<'static, u16>>,
+}
+
+impl PwmRegistersManager {
+    /// Create a DMA-enabled register manager for the PWM peripheral.
+    ///
+    /// # Safety
+    ///
+    /// This controls DMA hardware. As such, it must be unique. This requires:
+    ///
+    /// - This constructor must be called at most once.
+    /// - There must not be any other code that accesses the DMA buffer and
+    ///   length registers.
+    pub unsafe fn new(
+        registers: StaticRef<PwmRegisters>,
+        duty_cycles: &'static mut [u16; 4],
+    ) -> Self {
+        Self {
+            registers,
+            duty_cycles: MapCell::new(duty_cycles),
+            duty_cycles_dma: MapCell::empty(),
+        }
+    }
+
+    /// Whether the DMA hardware is active.
+    fn is_active(&self) -> bool {
+        self.duty_cycles_dma.is_some()
+    }
+
+    /// Start PWM using the DMA hardware.
+    pub fn start(&self, dc_out: u16) {
+        // If PWM is already running, we need to stop it an retrieve the DMAed
+        // buffer.
+        if self.is_active() {
+            self.stop();
+        }
+
+        if let Some(buf) = self.duty_cycles.take() {
+            // Setup the duty cycles.
+            buf[0] = dc_out;
+
+            // # Safety
+            //
+            // The architecture-provided version is correct for the nRF52.
+            let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+            // Create the DmaSliceMut for the duty cycle buffer. This ensures that
+            // we can soundly share it with the DMA hardware.
+            let dma_slice = DmaSliceMut::new_static(buf, fence);
+
+            // Provide the buffer pointer to the hardware DMA engine.
+            self.registers.seq0.seq_ptr.set(dma_slice.ptr_addr() as u32);
+            self.registers.seq0.seq_cnt.write(SEQ_CNT::CNT.val(1));
+            self.registers
+                .seq0
+                .seq_refresh
+                .write(SEQ_REFRESH::CNT.val(0));
+            self.registers
+                .seq0
+                .seq_enddelay
+                .write(SEQ_ENDDELAY::CNT.val(0));
+
+            // Clear any stale STOPPED event.
+            self.registers.events_stopped.write(EVENT::EVENT::CLEAR);
+
+            // Save the DmaSliceMut while the DMA hardware may access it.
+            self.duty_cycles_dma.replace(dma_slice);
+
+            // Start PWM.
+            self.registers.tasks_seqstart[0].write(TASK::TASK::SET);
+        }
+    }
+
+    /// Stop PWM pulse generation and reclaim the duty cycle buffer.
+    pub fn stop(&self) {
+        if !self.is_active() {
+            return;
+        }
+
+        // Stop the PWM hardware.
+        self.registers.tasks_stop.write(TASK::TASK::SET);
+
+        if let Some(dma_slice) = self.duty_cycles_dma.take() {
+            // # Safety
+            //
+            // The architecture-provided version is correct for the nRF52.
+            let fence = unsafe { cortexm4f::dma_fence::CortexMDmaFence::new() };
+
+            // SAFETY: We stopped the PWM hardware which ends its use of the
+            // duty cycles buffer.
+            let buf = unsafe { dma_slice.take(fence) };
+            self.duty_cycles.replace(buf);
+        }
+    }
+}
 
 pub struct Pwm {
-    registers: StaticRef<PwmRegisters>,
+    registers: PwmRegistersManager,
 }
 
 impl Pwm {
-    pub const fn new(registers: StaticRef<PwmRegisters>) -> Pwm {
+    pub fn new(registers: PwmRegistersManager) -> Pwm {
         Pwm { registers }
     }
 
@@ -209,51 +306,39 @@ impl Pwm {
         let dc_out = counter_top - ((3 * duty_cycle) / frequency_hz);
 
         // Configure the pin
-        self.registers.psel_out[0].set((*pin).into());
+        self.registers.registers.psel_out[0].set((*pin).into());
 
         // Start by enabling the peripheral.
-        self.registers.enable.write(ENABLE::ENABLE::SET);
+        self.registers.registers.enable.write(ENABLE::ENABLE::SET);
         // Want count up mode.
-        self.registers.mode.write(MODE::UPDOWN::Up);
+        self.registers.registers.mode.write(MODE::UPDOWN::Up);
         // Disable loop (repeat) mode.
-        self.registers.loopreg.write(LOOP::CNT.val(0));
+        self.registers.registers.loopreg.write(LOOP::CNT.val(0));
         // Set the decoder settings.
         self.registers
+            .registers
             .decoder
             .write(DECODER::LOAD::Common + DECODER::MODE::RefreshCount);
         // Set the prescaler.
-        self.registers.prescaler.write(PRESCALER::PRESCALER::DIV_1);
+        self.registers
+            .registers
+            .prescaler
+            .write(PRESCALER::PRESCALER::DIV_1);
         // Set the value to count to.
         self.registers
+            .registers
             .countertop
             .write(COUNTERTOP::COUNTERTOP.val(counter_top as u32));
 
-        // Setup the duty cycles
-        unsafe {
-            DUTY_CYCLES[0] = dc_out as u16;
-        }
-        let duty_cycles: *const [u16; 4] = core::ptr::addr_of!(DUTY_CYCLES);
-        let duty_cycles: *const u16 = duty_cycles.cast();
-        self.registers.seq0.seq_ptr.set(duty_cycles as u32);
-        self.registers.seq0.seq_cnt.write(SEQ_CNT::CNT.val(1));
-        self.registers
-            .seq0
-            .seq_refresh
-            .write(SEQ_REFRESH::CNT.val(0));
-        self.registers
-            .seq0
-            .seq_enddelay
-            .write(SEQ_ENDDELAY::CNT.val(0));
-
-        // Start
-        self.registers.tasks_seqstart[0].write(TASK::TASK::SET);
+        // Configure the PWM hardware through the DMA manager.
+        self.registers.start(dc_out as u16);
 
         Ok(())
     }
 
     fn stop_pwm(&self, _pin: &nrf5x::pinmux::Pinmux) -> Result<(), ErrorCode> {
-        self.registers.tasks_stop.write(TASK::TASK::SET);
-        self.registers.enable.write(ENABLE::ENABLE::CLEAR);
+        self.registers.stop();
+        self.registers.registers.enable.write(ENABLE::ENABLE::CLEAR);
         Ok(())
     }
 }

--- a/chips/nrf52832/src/interrupt_service.rs
+++ b/chips/nrf52832/src/interrupt_service.rs
@@ -14,9 +14,13 @@ pub struct Nrf52832DefaultPeripherals<'a> {
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
 impl<'a> Nrf52832DefaultPeripherals<'a> {
-    pub unsafe fn new(ficr: &'a nrf52::ficr::Ficr, aes_ecb_buf: &'static mut [u8; 48]) -> Self {
+    pub unsafe fn new(
+        ficr: &'a nrf52::ficr::Ficr,
+        aes_ecb_buf: &'static mut [u8; 48],
+        pwm_buf: &'static mut [u16; 4],
+    ) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(ficr, aes_ecb_buf),
+            nrf52: Nrf52DefaultPeripherals::new(ficr, aes_ecb_buf, pwm_buf),
             gpio_port: crate::gpio::nrf52832_gpio_create(),
         }
     }

--- a/chips/nrf52833/src/interrupt_service.rs
+++ b/chips/nrf52833/src/interrupt_service.rs
@@ -24,9 +24,10 @@ impl<'a> Nrf52833DefaultPeripherals<'a> {
         ficr: &'a nrf52::ficr::Ficr,
         ieee802154_radio_ack_buf: &'static mut [u8; crate::ieee802154_radio::ACK_BUF_SIZE],
         aes_ecb_buf: &'static mut [u8; 48],
+        pwm_buf: &'static mut [u16; 4],
     ) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(ficr, aes_ecb_buf),
+            nrf52: Nrf52DefaultPeripherals::new(ficr, aes_ecb_buf, pwm_buf),
             ieee802154_radio: crate::ieee802154_radio::Radio::new(
                 RADIO_BASE,
                 ieee802154_radio_ack_buf,

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -50,9 +50,10 @@ impl<'a> Nrf52840DefaultPeripherals<'a> {
         ficr: &'a nrf52::ficr::Ficr,
         ieee802154_radio_ack_buf: &'static mut [u8; crate::ieee802154_radio::ACK_BUF_SIZE],
         aes_ecb_buf: &'static mut [u8; 48],
+        pwm_buf: &'static mut [u16; 4],
     ) -> Self {
         // SAFETY: See function-level doc.
-        let nrf52_peripherals = unsafe { Nrf52DefaultPeripherals::new(ficr, aes_ecb_buf) };
+        let nrf52_peripherals = unsafe { Nrf52DefaultPeripherals::new(ficr, aes_ecb_buf, pwm_buf) };
 
         Self {
             nrf52: nrf52_peripherals,


### PR DESCRIPTION
### Pull Request Overview

This fixes the unsafe code that uses DMA for PWM, _and_ removes a `static mut`!

Actual change is pretty straightforward for this kind of work:

- Create new registers manager struct that is the only thing that accesses DMA registers
- That struct handles storing the DMAed buffer and calling fence and using dma_slice
- The static buffer given to DMA is now passed in to avoid the static mut in chips.

The one potentially slightly interesting thing is that since in this case the buffer isn't used for any data any other layer cares about, the dma register manager owns the buffer, and just swaps it between a normal rust buffer and a dma_slice.

This does touch every nrf52 board because we need to pass in the pwm static buffer.


### Testing Strategy

Writing new PWM apps and testing with a config board.


### TODO or Help Wanted

I have a question out on [element](https://matrix.to/#/!hUHxgpoqzFTCxREgkN:tockos.org/$74I62renXqnaV6WjTGSoeLBDmUmTvu9qKBX2S0AoKeo?via=princeton.systems&via=matrix.org&via=betterbytes.org) on how to handle DMA in this case. Stopping the PWM hardware seems to take about 50 ms. This makes pulsing an LED not work. I need to know how I can remove the `self.registers.tasks_stop.write(TASK::TASK::SET);` line and do something else instead to meet the DMA soundness requirements.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

I had claude do the first pass at making the register manager because it is just better and faster at all the boilerplate. However, I didn't really like its implementation so I rewrote it in many ways to change how buffers are handled. I reviewed the entire change to the nrf52/pwm.rs file.

I think had claude do all the mechanical work of updating each nrf52 board.
