### PR TITLE
boards: add a nRF52 Configuration Board for PWM testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,6 +1034,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "nrf52840dk-test-pwm"
+version = "0.2.3-dev"
+dependencies = [
+ "capsules-core",
+ "capsules-extra",
+ "capsules-system",
+ "components",
+ "cortexm4",
+ "kernel",
+ "nrf52840",
+ "nrf52840dk-test-base",
+ "nrf52_components",
+ "segger",
+ "tock_build_scripts",
+]
+
+[[package]]
 name = "nrf52840dk-test-sha256"
 version = "0.2.3-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ members = [
     "boards/configurations/nrf52840dk/nrf52840dk-test-kernel",
     "boards/configurations/nrf52840dk/nrf52840dk-test-dynamic-app-load",
     "boards/configurations/nrf52840dk/nrf52840dk-test-sha256",
+    "boards/configurations/nrf52840dk/nrf52840dk-test-pwm",
     "boards/configurations/microbit_v2/microbit_v2-test-dynamic-app-load",
     "boards/configurations/qemu_rv64_virt/qemu_rv64_virt-test-ci",
     "boards/tutorials/nrf52840dk-root-of-trust-tutorial",

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-base/src/lib.rs
@@ -21,10 +21,15 @@ use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 
 // The nRF52840DK LEDs (see back of board)
-const LED1_PIN: Pin = Pin::P0_13;
-const LED2_PIN: Pin = Pin::P0_14;
-const LED3_PIN: Pin = Pin::P0_15;
-const LED4_PIN: Pin = Pin::P0_16;
+
+/// LED1: top left
+pub const LED1_PIN: Pin = Pin::P0_13;
+/// LED2: top right
+pub const LED2_PIN: Pin = Pin::P0_14;
+/// LED3: bottom left
+pub const LED3_PIN: Pin = Pin::P0_15;
+/// LED4: bottom right
+pub const LED4_PIN: Pin = Pin::P0_16;
 
 const BUTTON_RST_PIN: Pin = Pin::P0_18;
 

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-pwm/Cargo.toml
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-pwm/Cargo.toml
@@ -1,0 +1,30 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+[package]
+name = "nrf52840dk-test-pwm"
+version.workspace = true
+authors.workspace = true
+build = "../../../build.rs"
+edition.workspace = true
+
+[dependencies]
+nrf52840dk-test-base = { path = "../nrf52840dk-test-base" }
+
+components = { path = "../../../components" }
+cortexm4 = { path = "../../../../arch/cortex-m4" }
+kernel = { path = "../../../../kernel" }
+nrf52840 = { path = "../../../../chips/nrf52840" }
+segger = { path = "../../../../chips/segger" }
+nrf52_components = { path = "../../../nordic/nrf52_components" }
+
+capsules-core = { path = "../../../../capsules/core" }
+capsules-extra = { path = "../../../../capsules/extra" }
+capsules-system = { path = "../../../../capsules/system" }
+
+[build-dependencies]
+tock_build_scripts = { path = "../../../build_scripts" }
+
+[lints]
+workspace = true

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-pwm/Makefile
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-pwm/Makefile
@@ -1,0 +1,6 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2026.
+
+include ../../../Makefile.common
+include ../nrf52840dk.mk

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-pwm/README.md
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-pwm/README.md
@@ -1,0 +1,11 @@
+nRF52840-DK PWM Test Board
+===================================
+
+This is a minimal kernel for testing the PWM stack without virtualization.
+
+Each of the four onboard LED pins is driven by its own, dedicated PWM
+hardware peripheral (PWM0-PWM3).
+
+Because those pins are being driven as PWM outputs, the LED driver is
+intercepted in `with_driver()` and always returns an error so userspace
+cannot also try to drive the same pins as plain digital outputs.

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-pwm/layout.ld
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-pwm/layout.ld
@@ -1,0 +1,6 @@
+/* Licensed under the Apache License, Version 2.0 or the MIT License. */
+/* SPDX-License-Identifier: Apache-2.0 OR MIT                         */
+/* Copyright Tock Contributors 2026.                                  */
+
+INCLUDE ../../../nordic/nrf52840_chip_layout.ld
+INCLUDE tock_kernel_layout.ld

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-pwm/src/main.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-pwm/src/main.rs
@@ -1,0 +1,240 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! Tock kernel for the Nordic Semiconductor nRF52840 development kit (DK).
+//!
+//! This configuration exercises the PWM stack using all four PWM hardware
+//! elements.
+
+#![no_std]
+#![no_main]
+#![deny(missing_docs)]
+
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::static_init;
+use kernel::utilities::StaticRef;
+use nrf52840::pwm::{PwmRegisters, PwmRegistersManager};
+
+mod pwm_pin;
+
+/// PWM1 Hardware Registers
+///
+/// # Safety
+///
+/// This is the correct location of a PWM instance:
+/// <https://docs.nordicsemi.com/r/bundle/ps_nrf52840/page/pwm.html#d1052e1269>.
+const PWM1_BASE: StaticRef<PwmRegisters> =
+    unsafe { StaticRef::new(0x40021000 as *const PwmRegisters) };
+
+/// PWM2 Hardware Registers
+///
+/// # Safety
+///
+/// This is the correct location of a PWM instance:
+/// <https://docs.nordicsemi.com/r/bundle/ps_nrf52840/page/pwm.html#d1052e1269>.
+const PWM2_BASE: StaticRef<PwmRegisters> =
+    unsafe { StaticRef::new(0x40022000 as *const PwmRegisters) };
+
+/// PWM3 Hardware Registers
+///
+/// # Safety
+///
+/// This is the correct location of a PWM instance:
+/// <https://docs.nordicsemi.com/r/bundle/ps_nrf52840/page/pwm.html#d1052e1269>.
+const PWM3_BASE: StaticRef<PwmRegisters> =
+    unsafe { StaticRef::new(0x4002D000 as *const PwmRegisters) };
+
+type ChipHw = nrf52840dk_test_base_lib::ChipHw;
+
+type PwmHw = nrf52840::pwm::Pwm;
+type PwmDriver = components::pwm::PwmDriverComponentType<4>;
+
+/// Supported drivers by the platform
+pub struct Platform {
+    base: nrf52840dk_test_base_lib::Platform,
+    pwm: &'static PwmDriver,
+}
+
+impl SyscallDriverLookup for Platform {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
+    {
+        match driver_num {
+            // The LED pins are being driven as PWM outputs, so intercept the
+            // LED driver and always return an error.
+            capsules_core::led::DRIVER_NUM => f(None),
+            capsules_extra::pwm::DRIVER_NUM => f(Some(self.pwm)),
+            _ => self.base.with_driver(driver_num, f),
+        }
+    }
+}
+
+impl KernelResources<ChipHw> for Platform {
+    type SyscallDriverLookup = Self;
+    type SyscallFilter =
+        <nrf52840dk_test_base_lib::Platform as KernelResources<ChipHw>>::SyscallFilter;
+    type ProcessFault =
+        <nrf52840dk_test_base_lib::Platform as KernelResources<ChipHw>>::ProcessFault;
+    type Scheduler = <nrf52840dk_test_base_lib::Platform as KernelResources<ChipHw>>::Scheduler;
+    type SchedulerTimer =
+        <nrf52840dk_test_base_lib::Platform as KernelResources<ChipHw>>::SchedulerTimer;
+    type WatchDog = <nrf52840dk_test_base_lib::Platform as KernelResources<ChipHw>>::WatchDog;
+    type ContextSwitchCallback =
+        <nrf52840dk_test_base_lib::Platform as KernelResources<ChipHw>>::ContextSwitchCallback;
+
+    fn syscall_driver_lookup(&self) -> &Self::SyscallDriverLookup {
+        self
+    }
+    fn syscall_filter(&self) -> &Self::SyscallFilter {
+        self.base.syscall_filter()
+    }
+    fn process_fault(&self) -> &Self::ProcessFault {
+        self.base.process_fault()
+    }
+    fn scheduler(&self) -> &Self::Scheduler {
+        self.base.scheduler()
+    }
+    fn scheduler_timer(&self) -> &Self::SchedulerTimer {
+        self.base.scheduler_timer()
+    }
+    fn watchdog(&self) -> &Self::WatchDog {
+        self.base.watchdog()
+    }
+    fn context_switch_callback(&self) -> &Self::ContextSwitchCallback {
+        self.base.context_switch_callback()
+    }
+}
+
+/// Main function called after RAM initialized.
+#[no_mangle]
+pub unsafe fn main() {
+    let (board_kernel, base_platform, chip, nrf52840_peripherals, _mux_uart, _mux_alarm) =
+        nrf52840dk_test_base_lib::start();
+    let base_peripherals = &nrf52840_peripherals.nrf52;
+
+    //--------------------------------------------------------------------------
+    // PWM
+    //--------------------------------------------------------------------------
+
+    // PWM0 is already set up as part of the shared chip peripherals.
+    let pwm0 = &base_peripherals.pwm0;
+
+    // Instantiate PWM1-PWM3 directly, each with its own duty-cycle buffer.
+    let pwm1_dutycycle_buf = static_init!([u16; 4], [0; 4]);
+    let pwm1_registers = PwmRegistersManager::new(PWM1_BASE, pwm1_dutycycle_buf);
+    let pwm1 = static_init!(PwmHw, PwmHw::new(pwm1_registers));
+
+    let pwm2_dutycycle_buf = static_init!([u16; 4], [0; 4]);
+    let pwm2_registers = PwmRegistersManager::new(PWM2_BASE, pwm2_dutycycle_buf);
+    let pwm2 = static_init!(PwmHw, PwmHw::new(pwm2_registers));
+
+    let pwm3_dutycycle_buf = static_init!([u16; 4], [0; 4]);
+    let pwm3_registers = PwmRegistersManager::new(PWM3_BASE, pwm3_dutycycle_buf);
+    let pwm3 = static_init!(PwmHw, PwmHw::new(pwm3_registers));
+
+    // Each LED pin gets its own, dedicated PWM hardware peripheral rather
+    // than sharing one peripheral through a virtualizer.
+    let pwm_pin1 = static_init!(
+        pwm_pin::PwmPinStatic<'static, PwmHw>,
+        pwm_pin::PwmPinStatic::new(
+            pwm0,
+            nrf52840::pinmux::Pinmux::new(nrf52840dk_test_base_lib::LED1_PIN)
+        )
+    );
+    let pwm_pin2 = static_init!(
+        pwm_pin::PwmPinStatic<'static, PwmHw>,
+        pwm_pin::PwmPinStatic::new(
+            pwm1,
+            nrf52840::pinmux::Pinmux::new(nrf52840dk_test_base_lib::LED2_PIN)
+        )
+    );
+    let pwm_pin3 = static_init!(
+        pwm_pin::PwmPinStatic<'static, PwmHw>,
+        pwm_pin::PwmPinStatic::new(
+            pwm2,
+            nrf52840::pinmux::Pinmux::new(nrf52840dk_test_base_lib::LED3_PIN)
+        )
+    );
+    let pwm_pin4 = static_init!(
+        pwm_pin::PwmPinStatic<'static, PwmHw>,
+        pwm_pin::PwmPinStatic::new(
+            pwm3,
+            nrf52840::pinmux::Pinmux::new(nrf52840dk_test_base_lib::LED4_PIN)
+        )
+    );
+
+    let pwm = components::pwm::PwmDriverComponent::new(
+        board_kernel,
+        capsules_extra::pwm::DRIVER_NUM,
+        create_capability!(capabilities::MemoryAllocationCapability),
+    )
+    .finalize(components::pwm_driver_component_helper!(
+        pwm_pin1, pwm_pin2, pwm_pin3, pwm_pin4,
+    ));
+
+    //--------------------------------------------------------------------------
+    // PLATFORM
+    //--------------------------------------------------------------------------
+
+    let platform = Platform {
+        base: base_platform,
+        pwm,
+    };
+
+    //--------------------------------------------------------------------------
+    // PROCESS LOADING
+    //--------------------------------------------------------------------------
+
+    // These symbols are defined in the standard Tock linker script.
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+        /// End of the ROM region containing app images.
+        static _eapps: u8;
+        /// Beginning of the RAM region for app memory.
+        static mut _sappmem: u8;
+        /// End of the RAM region for app memory.
+        static _eappmem: u8;
+    }
+
+    let app_flash = core::slice::from_raw_parts(
+        core::ptr::addr_of!(_sapps),
+        core::ptr::addr_of!(_eapps) as usize - core::ptr::addr_of!(_sapps) as usize,
+    );
+    let app_memory = core::slice::from_raw_parts_mut(
+        core::ptr::addr_of_mut!(_sappmem),
+        core::ptr::addr_of!(_eappmem) as usize - core::ptr::addr_of!(_sappmem) as usize,
+    );
+
+    let process_management_capability =
+        create_capability!(capabilities::ProcessManagementCapability);
+    kernel::process::load_processes(
+        board_kernel,
+        chip,
+        app_flash,
+        app_memory,
+        &nrf52840dk_test_base_lib::FAULT_RESPONSE,
+        &process_management_capability,
+    )
+    .unwrap_or_else(|err| {
+        kernel::debug!("Error loading processes!");
+        kernel::debug!("{:?}", err);
+    });
+
+    //--------------------------------------------------------------------------
+    // PLATFORM SETUP, SCHEDULER, AND START KERNEL LOOP
+    //--------------------------------------------------------------------------
+
+    let main_loop_capability = create_capability!(kernel::capabilities::MainLoopCapability);
+    board_kernel.kernel_loop(
+        &platform,
+        chip,
+        None::<&kernel::ipc::IPC<0>>,
+        &main_loop_capability,
+    );
+}

--- a/boards/configurations/nrf52840dk/nrf52840dk-test-pwm/src/pwm_pin.rs
+++ b/boards/configurations/nrf52840dk/nrf52840dk-test-pwm/src/pwm_pin.rs
@@ -1,0 +1,44 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2026.
+
+//! A `hil::pwm::PwmPin` for a `hil::pwm::Pwm` that is dedicated to one pin.
+//!
+//! This looks a lot like
+//! `capsules_core::virtualizers::virtual_pwm::PwmPinUser`, except it does not
+//! multiplex several pins onto a shared `MuxPwm`. It assumes the underlying
+//! `Pwm` instance is exclusively owned by this one pin.
+
+use kernel::ErrorCode;
+use kernel::hil;
+
+/// Exposes a single pin on a dedicated (non-shared) PWM peripheral as a
+/// `PwmPin`.
+pub struct PwmPinStatic<'a, P: hil::pwm::Pwm> {
+    pwm: &'a P,
+    pin: P::Pin,
+}
+
+impl<'a, P: hil::pwm::Pwm> PwmPinStatic<'a, P> {
+    pub const fn new(pwm: &'a P, pin: P::Pin) -> Self {
+        PwmPinStatic { pwm, pin }
+    }
+}
+
+impl<P: hil::pwm::Pwm> hil::pwm::PwmPin for PwmPinStatic<'_, P> {
+    fn start(&self, frequency_hz: usize, duty_cycle: usize) -> Result<(), ErrorCode> {
+        self.pwm.start(&self.pin, frequency_hz, duty_cycle)
+    }
+
+    fn stop(&self) -> Result<(), ErrorCode> {
+        self.pwm.stop(&self.pin)
+    }
+
+    fn get_maximum_frequency_hz(&self) -> usize {
+        self.pwm.get_maximum_frequency_hz()
+    }
+
+    fn get_maximum_duty_cycle(&self) -> usize {
+        self.pwm.get_maximum_duty_cycle()
+    }
+}

--- a/capsules/extra/src/pwm.rs
+++ b/capsules/extra/src/pwm.rs
@@ -112,10 +112,25 @@ impl<const NUM_PINS: usize> SyscallDriver for Pwm<'_, NUM_PINS> {
                         // Duty cycle is represented as a 4 digit number, so we divide by 10000 to get the percentage of the max duty cycle.
                         // e.g.: a duty cycle of 60.5% is represented as 6050, so the actual value of the duty cycle is
                         // 6050 * max_duty_cycle / 10000 = 0.605 * max_duty_cycle
+                        //
+                        // However, the max duty cycle might be large enough to overflow a u32, so
+                        // we cast to u64 to do the calculation.
+                        const fn ratio_max_duty_cycle(
+                            duty_cycle_hundredths: usize,
+                            max_cycles: usize,
+                        ) -> usize {
+                            let cycles_hundredths: u64 =
+                                duty_cycle_hundredths as u64 * max_cycles as u64;
+                            (cycles_hundredths / 10000) as usize
+                        }
+
                         self.pwm_pins[pin]
                             .start(
                                 frequency_hz,
-                                duty_cycle * self.pwm_pins[pin].get_maximum_duty_cycle() / 10000,
+                                ratio_max_duty_cycle(
+                                    duty_cycle,
+                                    self.pwm_pins[pin].get_maximum_duty_cycle(),
+                                ),
                             )
                             .into()
                     }


### PR DESCRIPTION
### Pull Request Overview

This config board enables all four PWM hardware lines on the same pins as the LEDs on the nrf52840dk. This allows for testing the PWM driver by viewing the LEDs.


### Testing Strategy

Running this with a PWM test libtock-c app.


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [ ] No AI was used in this PR.
- [x] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

Claude generated the config board and wrote the small adapter from PwmPin to Pwm. Pretty straightforward stuff. I reviewed all of the comments and made some tweaks. I even made a try at writing some safety docs for static ref!
