### PR TITLE
doc: fix two doc warnings

### DIFF
--- a/capsules/extra/src/syscall_return_test.rs
+++ b/capsules/extra/src/syscall_return_test.rs
@@ -4,7 +4,7 @@
 
 //! Capsule for testing syscall return variants from userspace.
 //!
-//! Each command returns a specific [`SyscallReturn`] variant with distinct,
+//! Each command returns a specific [`CommandReturn`] variant with distinct,
 //! known values so userspace tests can verify correct encoding and decoding
 //! of every return type.
 //!

--- a/kernel/src/utilities/helpers.rs
+++ b/kernel/src/utilities/helpers.rs
@@ -171,7 +171,7 @@ macro_rules! create_typed_capability {
 /// only defines a visibly named type, it does not create any instances.
 /// Use this when you need to name the capability type across scope boundaries.
 ///
-/// Use [`mint_defined_capability!`] to create an instance. Note: You can only
+/// Use `mint_defined_capability!` to create an instance. Note: You can only
 /// mint capabilities in the module that defines this type, or in a descendant
 /// of that module.
 ///


### PR DESCRIPTION
### Pull Request Overview

Minor upkeep PR. 

The macro one is interesting:

```
warning: unresolved link to `mint_defined_capability`
   --> kernel/src/utilities/helpers.rs:174:11
    |
174 | /// Use [`mint_defined_capability!`] to create an instance. Note: You can only
    |           ^^^^^^^^^^^^^^^^^^^^^^^^ no item named `mint_defined_capability` in scope
    |
    = note: `macro_rules` named `mint_defined_capability` exists in this crate, but it is not in scope at this link's location
    = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
```


### Testing Strategy

`cargo doc`


### TODO or Help Wanted

n/a


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

<!-- Include details of AI use here, if you used any -->
