### PR TITLE
arch/x86: remove redundant rustdoc explicit target

### DIFF
--- a/arch/x86/src/interrupts/poller.rs
+++ b/arch/x86/src/interrupts/poller.rs
@@ -62,8 +62,8 @@ impl InterruptPoller {
     /// Provides safe access to the singleton instance of `InterruptPoller`.
     ///
     /// The given closure `f` is executed with interrupts disabled (using
-    /// [`support::with_interrupts_disabled`](crate::support::with_interrupts_disabled))
-    /// and  passed a reference to the singleton.
+    /// [`support::with_interrupts_disabled`]) and passed a reference to the
+    /// singleton.
     pub fn access<F, R>(f: F) -> R
     where
         F: FnOnce(&InterruptPoller) -> R,


### PR DESCRIPTION
### Pull Request Overview

This pull request resolves the following Clippy lint:

```
error: redundant explicit link target
  --> arch/x86/src/interrupts/poller.rs:65:47
   |
65 |     /// [`support::with_interrupts_disabled`](crate::support::with_interrupts_disabled))
   |          -----------------------------------  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ explicit target is redundant
   |          |
   |          because label contains path that resolves to same destination
   |
   = note: when a link's destination is not specified,
           the label is used to resolve intra-doc links
   = note: `-D rustdoc::redundant-explicit-links` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(rustdoc::redundant_explicit_links)]`
help: remove explicit link target
   |
65 -     /// [`support::with_interrupts_disabled`](crate::support::with_interrupts_disabled))
65 +     /// [`support::with_interrupts_disabled`])
```


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [X] No documentation updates are required.

#### AI Use

- [X] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

<!-- Include details of AI use here, if you used any -->
