### PR TITLE
chips/{pci-x86,x86_q35}: fix rustdoc warnings

### DIFF
--- a/chips/pci-x86/src/device.rs
+++ b/chips/pci-x86/src/device.rs
@@ -105,9 +105,10 @@ pub type StatusVal = LocalRegisterCopy<u16, Status::Register>;
 /// }
 /// ```
 ///
-/// Alternatively, you can use the [`iter`][crate::iter] function to enumerate all PCI devices in
-/// the system. This method automatically filters out non-existent devices, and it returns an
-/// iterator which can be chained like any other Rust iterator:
+/// Alternatively, you can use the [`iter`][crate::iter()] function to enumerate
+/// all PCI devices in the system. This method automatically filters out
+/// non-existent devices, and it returns an iterator which can be chained like
+/// any other Rust iterator:
 ///
 /// ```ignore
 /// let dev = pci::iter().find(|d| d.vendor_id() == 0x1234 && d.device_id() == 0x5678);

--- a/chips/x86_q35/src/ps2.rs
+++ b/chips/x86_q35/src/ps2.rs
@@ -114,7 +114,7 @@ impl core::fmt::Display for Ps2Health {
 
 /// Note: There is no hardware interrupt when the input buffer empties, so we must poll bit 1.
 /// See OSDev documentation:
-/// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
+/// <https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register>
 ///
 /// Block until the controller’s input buffer is empty (ready for a command).
 #[inline(always)]
@@ -131,7 +131,7 @@ fn wait_ib_empty_with_timeout(limit: usize) -> Result<(), Ps2Error> {
 
 /// Data-ready events trigger IRQ1, handled asynchronously in `handle_interrupt()`.
 /// See OSDev documentation:
-/// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
+/// <https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register>
 ///
 /// Block until there is data ready to read in the output buffer.
 #[inline(always)]


### PR DESCRIPTION
### Pull Request Overview
Fixes two rustdoc warnings in the `pci-x86` and `x86_q35` chip crates:

```
error: this URL is not a hyperlink
   --> chips/x86_q35/src/ps2.rs:117:5
    |
117 | /// https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
    = note: `-D rustdoc::bare-urls` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(rustdoc::bare_urls)]`
help: use an automatic link instead
    |
117 | /// <https://wiki.osdev.org/I8042_PS/2_Controller#Status_Register>
    |     +                                                            +
```

and

```
error: `crate::iter` is both a function and a module
   --> chips/pci-x86/src/device.rs:108:45
    |
108 | /// Alternatively, you can use the [`iter`][crate::iter] function to enumerate all PCI devices in
    |                                             ^^^^^^^^^^^ ambiguous link
    |
    = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(rustdoc::broken_intra_doc_links)]`
help: to link to the function, add parentheses
    |
108 | /// Alternatively, you can use the [`iter`][crate::iter()] function to enumerate all PCI devices in
    |                                                        ++
help: to link to the module, prefix with `mod@`
    |
108 | /// Alternatively, you can use the [`iter`][mod@crate::iter] function to enumerate all PCI devices in
    |                                             ++++
```

### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Checklist

- [ ] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [X] No documentation updates are required.

#### AI Use

- [X] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md#ai-policy) and have properly disclosed my AI use below. This PR comment, and any subsequent PR interactions must not be generated using AI, except for under a `<details>` drawer.

<!-- Include details of AI use here, if you used any -->
